### PR TITLE
Update dockerfile to make yarn install outside of the app folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,19 @@ FROM node
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
 
-WORKDIR /usr/src
-COPY package.json /usr/src
-RUN yarn install && yarn cache clean --force
-ENV PATH /usr/src/node_modules/.bin:$PATH
+RUN mkdir -p /usr/src/app &&\
+  echo "--modules-folder /usr/src/node_modules" > /root/.yarnrc
 ENV NPM_CONFIG_PREFIX /usr/src/node_modules
+ENV PATH /usr/src/node_modules/.bin:$PATH
+COPY package.json /usr/src
+COPY yarn.lock /usr/src
+WORKDIR /usr/src
 
-WORKDIR /usr/src/app
+RUN yarn install && yarn cache clean --force
+
 COPY . /usr/src/app
+
+RUN cp package.json /usr/src/app && cp yarn.lock /usr/src/app
+WORKDIR /usr/src/app
 
 CMD ["yarn", "test"]


### PR DESCRIPTION
With this change:
- yarn install/add/upgrade etc will target /usr/src/node_modules
- make build will update the node_modules if the yarn.lock is changed

This means that if you are inside the container and need to install a
new package you can just run `yarn add` and not worry about it creating
a node_modules folder owned by root that will be mirrored back to your
host machine.

Also it means that for users of Docker for Mac, which has a well known
issue with slow file access on nfs mounts, yarn will be as fast as it
would be locally. Before this change a `yarn install` could take 3-4
mins and an `npm install` could take 15 mins.

NOTE: I've had to first copy the package.json and yarn.lock in to
`/usr/src/` as yarn doesn't support the creation of `.bin` folders in
the modules-folder path yet. v0.28.4 when it releases will fix this.