### PR TITLE
Simple sessions

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -1,1 +1,2 @@
 NODE_ENV: NODE_ENV
+secret: SECRET

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -1,1 +1,1 @@
-secret: 'abcdef12345'
+NODE_ENV: 'testing'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     ports:
       - "9229:9229"
       - "3000:3000"
+    environment:
+      REDIS_URL: 'redis://redis:6379'
     links:
       - redis
 
   redis:
     image: redis
-    expose:
-      - 6789

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,10 @@ services:
     ports:
       - "9229:9229"
       - "3000:3000"
+    links:
+      - redis
+
+  redis:
+    image: redis
+    expose:
+      - 6789

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -9,18 +9,25 @@ const Sessions = require('./steps/Sessions');
 
 const app = express();
 
+const baseUrl = `http://localhost:${config.port}`;
+
 lookAndFeel.configure(app, {
-  baseUrl: `http://localhost:${config.port}`,
+  baseUrl,
   express: { views: [path.resolve(__dirname, 'views')] },
   webpack: { entry: [path.resolve(__dirname, 'assets/scss/main.scss')] }
 });
 
 journey(app, {
+  baseUrl,
   steps: [
     new HelloWorld(),
     new CreateSession(),
     new Sessions()
-  ]
+  ],
+  session: {
+    redis: { url: config.redisUrl },
+    cookie: { secure: false }
+  }
 });
 
 app.listen(config.port);

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -1,7 +1,7 @@
 const config = require('config');
 const express = require('express');
 const path = require('path');
-const { Journey } = require('@hmcts/one-per-page');
+const { journey } = require('@hmcts/one-per-page');
 const lookAndFeel = require('@hmcts/look-and-feel');
 const HelloWorld = require('./steps/HelloWorld');
 
@@ -13,7 +13,6 @@ lookAndFeel.configure(app, {
   webpack: { entry: [path.resolve(__dirname, 'assets/scss/main.scss')] }
 });
 
-const helloworldJourney = new Journey({ steps: [new HelloWorld()] });
-app.use(helloworldJourney);
+journey(app, { steps: [new HelloWorld()] });
 
 app.listen(config.port);

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -4,6 +4,8 @@ const path = require('path');
 const { journey } = require('@hmcts/one-per-page');
 const lookAndFeel = require('@hmcts/look-and-feel');
 const HelloWorld = require('./steps/HelloWorld');
+const CreateSession = require('./steps/CreateSession');
+const Sessions = require('./steps/Sessions');
 
 const app = express();
 
@@ -13,6 +15,12 @@ lookAndFeel.configure(app, {
   webpack: { entry: [path.resolve(__dirname, 'assets/scss/main.scss')] }
 });
 
-journey(app, { steps: [new HelloWorld()] });
+journey(app, {
+  steps: [
+    new HelloWorld(),
+    new CreateSession(),
+    new Sessions()
+  ]
+});
 
 app.listen(config.port);

--- a/examples/test-app/config/custom-environment-variables.yml
+++ b/examples/test-app/config/custom-environment-variables.yml
@@ -1,0 +1,1 @@
+redisUrl: REDIS_URL

--- a/examples/test-app/config/default.yml
+++ b/examples/test-app/config/default.yml
@@ -1,2 +1,3 @@
 port: 3000
 secret: 'iamnotaverygoodsecret'
+redisUrl: redis://127.0.0.1:6379

--- a/examples/test-app/config/default.yml
+++ b/examples/test-app/config/default.yml
@@ -1,1 +1,2 @@
 port: 3000
+secret: 'iamnotaverygoodsecret'

--- a/examples/test-app/steps/CreateSession.js
+++ b/examples/test-app/steps/CreateSession.js
@@ -1,0 +1,15 @@
+const { Page } = require('@hmcts/one-per-page');
+
+class CreateSession extends Page {
+  get url() {
+    return '/create-session';
+  }
+
+  handler(req, res) {
+    req.session.generate();
+    req.session.username = 'Michael';
+    res.redirect('/sessions');
+  }
+}
+
+module.exports = CreateSession;

--- a/examples/test-app/steps/Sessions.js
+++ b/examples/test-app/steps/Sessions.js
@@ -1,0 +1,16 @@
+const { Page } = require('@hmcts/one-per-page');
+
+class Sessions extends Page {
+  get url() {
+    return '/sessions';
+  }
+
+  handler(req, res) {
+    req.sessionStore.all((error, sessions) => {
+      const indentTwoSpaces = 2;
+      res.send(JSON.stringify(sessions, null, indentTwoSpaces));
+    });
+  }
+}
+
+module.exports = Sessions;

--- a/examples/test-app/views/HelloWorld.html
+++ b/examples/test-app/views/HelloWorld.html
@@ -10,5 +10,6 @@
 {{ header("Hello World!") }}
 
 <p>A basic page.</p>
+<p>Hello, {{ session.username }} (loaded from session)</p>
 
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "config": "^1.26.1",
+    "connect-redis": "^3.3.0",
     "express": "^4.15.3",
     "express-nunjucks": "^2.2.3",
     "express-session": "^1.15.4",
     "http-status-codes": "^1.2.0",
     "js-yaml": "^3.9.0",
     "nunjucks": "^3.0.1",
-    "router": "^1.3.1"
+    "router": "^1.3.1",
+    "url-parse": "^1.1.9"
   },
   "devDependencies": {
     "@hmcts/eslint-config": "^1.0.1",
@@ -31,6 +33,9 @@
     "eslint": "^4.3.0",
     "mocha": "^3.4.2",
     "nyc": "^11.1.0",
+    "proxyquire": "^1.8.0",
+    "sinon": "^3.2.1",
+    "sinon-chai": "^2.13.0",
     "supertest": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
-    "config": "^1.26.1",
+    "config": "^1.26.2",
     "connect-redis": "^3.3.0",
     "express": "^4.15.3",
     "express-nunjucks": "^2.2.3",
@@ -26,11 +26,11 @@
     "url-parse": "^1.1.9"
   },
   "devDependencies": {
-    "@hmcts/eslint-config": "^1.0.1",
+    "@hmcts/eslint-config": "^1.0.5",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "codacy-coverage": "^2.0.2",
-    "eslint": "^4.3.0",
+    "eslint": "^4.5.0",
     "mocha": "^3.4.2",
     "nyc": "^11.1.0",
     "proxyquire": "^1.8.0",

--- a/src/Journey.js
+++ b/src/Journey.js
@@ -1,16 +1,11 @@
-const Router = require('router');
 
 const defaults = { steps: [] };
 
-class Journey extends Router {
-  constructor(options = defaults) {
-    console.log(options);
-    super();
-    this.steps = options.steps;
-    this.steps.forEach(step => {
-      this.use(step.router);
-    });
-  }
-}
+const journey = (app, { steps = defaults.steps } = defaults) => {
+  steps.forEach(step => {
+    app.use(step.router);
+  });
+  return app;
+};
 
-module.exports = Journey;
+module.exports = journey;

--- a/src/Journey.js
+++ b/src/Journey.js
@@ -1,9 +1,24 @@
 const sessions = require('./services/sessions');
+const urlParse = require('url-parse');
 
-const defaults = { steps: [] };
+const parseUrl = baseUrl => {
+  if (typeof baseUrl === 'undefined') {
+    throw new Error('Must provide a baseUrl');
+  }
+  return urlParse(baseUrl);
+};
 
-const journey = (app, { steps = defaults.steps } = defaults) => {
-  app.use(sessions());
+const journey = (app, { baseUrl, steps = [], session = {} } = {}) => {
+  if (typeof session === 'function') {
+    app.use(session);
+  } else {
+    const cookie = Object.assign(
+      { domain: parseUrl(baseUrl).hostname },
+      session.cookie || {}
+    );
+    const sessionOptions = Object.assign({}, session, { cookie });
+    app.use(sessions(sessionOptions));
+  }
   steps.forEach(step => {
     app.use(step.router);
   });

--- a/src/Journey.js
+++ b/src/Journey.js
@@ -1,7 +1,9 @@
+const sessions = require('./services/sessions');
 
 const defaults = { steps: [] };
 
 const journey = (app, { steps = defaults.steps } = defaults) => {
+  app.use(sessions());
   steps.forEach(step => {
     app.use(step.router);
   });

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 const BaseStep = require('./steps/BaseStep');
 const Page = require('./steps/Page');
-const Journey = require('./Journey');
+const journey = require('./Journey');
 
 module.exports = {
   Page,
   BaseStep,
-  Journey
+  journey
 };

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1,6 +1,5 @@
 const session = require('express-session');
 const config = require('config');
-const isTest = require('../util/isTest');
 const shims = require('./sessions/shims');
 
 const expressSession = options => {
@@ -35,9 +34,7 @@ const overrides = (req, res, next) => error => {
 
 const sessions = (options = {}) => {
   const provider = expressSession(options);
-  return (req, res, next) => {
-    return provider(req, res, overrides(req, res, next));
-  };
+  return (req, res, next) => provider(req, res, overrides(req, res, next));
 };
 
 module.exports = sessions;

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1,6 +1,7 @@
 const session = require('express-session');
 const config = require('config');
 const isTest = require('../util/isTest');
+const shims = require('./sessions/shims');
 
 const expressSession = options => {
   const settings = Object.assign({}, {
@@ -8,22 +9,34 @@ const expressSession = options => {
     secret: config.secret,
     resave: false,
     saveUninitialized: false,
+    name: 'session',
     cookie: { secure: false }
   }, options);
   return session(settings);
 };
 
-const overrides = (req, res, next) => () => {
+const overrides = (req, res, next) => error => {
+  if (error) {
+    next(error);
+    return;
+  }
   res.locals = res.locals || {};
   // Should page render be able to access session directly?
   res.locals.session = req.session;
+
+  req.session.generate = shims.generate(req);
+  req.session.active = shims.active(req);
+  req.sessionStore.set = shims.set(req);
+  req.sessionStore.get = shims.get(req);
+  req.sessionStore.createSession = shims.createSession(req);
+
   next();
 };
 
 const sessions = (options = {}) => {
   const provider = expressSession(options);
   return (req, res, next) => {
-    provider(req, res, overrides(req, res, next));
+    return provider(req, res, overrides(req, res, next));
   };
 };
 

--- a/src/services/sessions/shims.js
+++ b/src/services/sessions/shims.js
@@ -1,0 +1,51 @@
+const activeProperty = Symbol('active');
+
+const defineNotEnumerable = (target, property, value) => {
+  Object.defineProperty(target, property, {
+    enumerable: false,
+    value,
+    writable: true
+  });
+};
+
+const generate = req => () => {
+  if (req.session && typeof req.session.id === 'string') {
+    req.session.destroy();
+  }
+  req.sessionStore.generate(req);
+  defineNotEnumerable(req.session, activeProperty, true);
+};
+
+const active = req => () => req.session && req.session[activeProperty];
+
+const set = req => {
+  const _set = req.sessionStore.set;
+
+  return (sessionId, session, onSet) => {
+    const metadata = { active: session[activeProperty] };
+    const modified = Object.assign({}, session, { metadata });
+
+    return _set.call(req.sessionStore, sessionId, modified, onSet);
+  };
+};
+
+const get = req => {
+  const _get = req.sessionStore.get;
+
+  return (sessionId, onLoad) => {
+    return _get.call(req.sessionStore, sessionId, onLoad);
+  };
+};
+
+const createSession = req => {
+  const _createSession = req.sessionStore.createSession;
+
+  return (request, sessionDataPlusMetadata) => {
+    const { metadata, ...sessionData } = sessionDataPlusMetadata;
+    const session = _createSession.call(request.sessionStore, request, sessionData);
+    defineNotEnumerable(session, activeProperty, metadata.active);
+    return session;
+  };
+};
+
+module.exports = { generate, active, get, set, createSession };

--- a/test/Journey.test.js
+++ b/test/Journey.test.js
@@ -1,4 +1,4 @@
-const Journey = require('../src/Journey');
+const journey = require('../src/Journey');
 const { supertest, testApp } = require('./util/supertest');
 const { OK } = require('http-status-codes');
 const { expect } = require('./util/chai');
@@ -15,8 +15,8 @@ class TestPage extends Page {
 }
 
 describe('Journey', () => {
-  it('returns an express router', () => {
-    const testJourney = new Journey();
+  it('returns an express app', () => {
+    const testJourney = journey(testApp());
 
     expect(testJourney).to.be.a('function');
     expect(testJourney).itself.to.respondTo('use');
@@ -25,10 +25,7 @@ describe('Journey', () => {
   });
 
   it('binds steps to the router', () => {
-    const myJourney = new Journey({ steps: [new TestPage()] });
-    const app = testApp();
-    app.use(myJourney);
-
+    const app = journey(testApp(), { steps: [new TestPage()] });
     return supertest(app).get(testUrl).expect(OK);
   });
 });

--- a/test/services/sessions.test.js
+++ b/test/services/sessions.test.js
@@ -2,46 +2,162 @@ const sessions = require('../../src/services/sessions');
 const { expect } = require('../util/chai');
 const { testApp, supertest } = require('../util/supertest');
 const { MemoryStore } = require('express-session');
-const { OK } = require('http-status-codes');
+const { OK, INTERNAL_SERVER_ERROR } = require('http-status-codes');
+
+const respondOk = (req, res) => res.sendStatus(OK);
+const handleError = (res, next) => {
+  return error => {
+    if (error && !res._header) {
+      res.statusCode = error.status || INTERNAL_SERVER_ERROR;
+      res.end(error.message);
+    } else {
+      next();
+    }
+  };
+};
+
+const createServer = (options, {
+  respond = respondOk,
+  setup = () => { /* intentionally blank */ }
+} = {}) => {
+  const cookieOptions = Object.assign({ maxAge: 60 * 1000 }, options.cookie);
+  const opts = Object.assign({}, { secret: 'keyboard cat' }, options);
+  opts.cookie = cookieOptions;
+  const s = sessions(opts);
+  const app = testApp();
+
+  app.use((req, res, next) => {
+    setup(req, res);
+    next();
+  });
+  app.use((req, res, next) => {
+    s(req, res, handleError(res, next));
+  });
+  app.use(respond);
+
+  return app;
+};
+
+const shouldNotSetCookie = name => {
+  return res => Promise.all([
+    expect(Object.keys(res.headers)).to.not.include('set-cookie'),
+    expect(res.headers['set-cookie']).to.not.include.match(name)
+  ]);
+};
+
+const shouldSetCookie = name => {
+  return res => Promise.all([
+    expect(Object.keys(res.headers)).to.include('set-cookie'),
+    expect(res.headers['set-cookie']).to.include.match(name)
+  ]).then(() => res);
+};
+
+const cookie = res => {
+  const setCookie = res.headers['set-cookie'];
+  return (setCookie && setCookie[0]) || undefined;
+};
+
+const shouldHave = number => {
+  return {
+    sessionsIn(store) {
+      return res => {
+        const promise = new Promise((resolve, reject) => {
+          store.all((error, sess) => {
+            if (error) {
+              reject(error);
+            } else {
+              const currentSessions = Object.keys(sess).length;
+              resolve(expect(currentSessions).to.eql(number));
+            }
+          });
+        });
+        return promise.then(() => res);
+      };
+    }
+  };
+};
 
 describe('services/sessions', () => {
   it('presents an express middleware', () => {
     const s = sessions();
     expect(s).to.be.a('function');
   });
-  it('accepts express-session session stores', () => {
-    const store = new MemoryStore();
-    const app = testApp();
-    expect(store.sessions).to.be.empty;
-    const s = sessions({ store });
-    app.use(s);
-    app.get('/', (req, res) => {
-      req.session.foo = 'foo';
-      res.sendStatus(OK);
-    });
+
+  it('bubbles up express-session errors', () => {
+    const app = createServer({ secret: undefined });
     return supertest(app)
-      .get('/').expect(200)
-      .then(response => {
-        const cookies = response.headers['set-cookie'];
-        expect(cookies).to.include.match(/connect.sid/);
-        expect(store.sessions).to.not.be.empty;
-      });
+      .get('/')
+      .expect(500);
   });
-  it('only initialises sessions when data is stored', () => {
+
+  it('creates sessions when session.generate is called', () => {
     const store = new MemoryStore();
-    const app = testApp();
-    expect(store.sessions).to.be.empty;
-    const s = sessions({ store });
-    app.use(s);
-    app.get('/', (req, res) => {
-      res.sendStatus(OK);
+    const app = createServer({ store }, {
+      respond(req, res) {
+        req.session.generate();
+        res.end();
+      }
     });
     return supertest(app)
-      .get('/').expect(200)
-      .then(response => {
-        const cookies = response.headers['set-cookie'];
-        expect(cookies).to.be.undefined;
-        expect(store.sessions).to.be.empty;
-      });
+      .get('/')
+      .expect(200)
+      .expect(shouldSetCookie(/session/))
+      .then(shouldHave(1).sessionsIn(store));
+  });
+
+  it('initialises sessions when data is stored', () => {
+    const store = new MemoryStore();
+    const app = createServer({ store });
+    return supertest(app)
+      .get('/')
+      .expect(200)
+      .expect(shouldNotSetCookie(/session/))
+      .then(shouldHave(0).sessionsIn(store));
+  });
+
+  it('destroys an existing session on generate', () => {
+    const store = new MemoryStore();
+    const app = createServer({ store }, {
+      respond(req, res) {
+        req.session.generate();
+        res.end();
+      }
+    });
+    return supertest(app)
+      .get('/')
+      .expect(200)
+      .then(first => {
+        return supertest(app)
+          .get('/')
+          .set('Cookie', cookie(first))
+          .expect(200)
+          .expect(shouldSetCookie(/session/))
+          .then(second => expect(cookie(first)).to.not.eql(cookie(second)));
+      })
+      .then(shouldHave(1).sessionsIn(store));
+  });
+
+  it('loads sessions correctly', () => {
+    const store = new MemoryStore();
+    const app = createServer({ store }, {
+      respond(req, res) {
+        if (req.session.active()) {
+          res.end('session loaded');
+        } else {
+          req.session.generate();
+          res.end('session created');
+        }
+      }
+    });
+    return supertest(app)
+      .get('/')
+      .expect(200, 'session created')
+      .then(first => {
+        return supertest(app)
+          .get('/')
+          .set('Cookie', cookie(first))
+          .expect(200, 'session loaded');
+      })
+      .then(shouldHave(1).sessionsIn(store));
   });
 });

--- a/test/services/sessions.test.js
+++ b/test/services/sessions.test.js
@@ -1,0 +1,47 @@
+const sessions = require('../../src/services/sessions');
+const { expect } = require('../util/chai');
+const { testApp, supertest } = require('../util/supertest');
+const { MemoryStore } = require('express-session');
+const { OK } = require('http-status-codes');
+
+describe('services/sessions', () => {
+  it('presents an express middleware', () => {
+    const s = sessions();
+    expect(s).to.be.a('function');
+  });
+  it('accepts express-session session stores', () => {
+    const store = new MemoryStore();
+    const app = testApp();
+    expect(store.sessions).to.be.empty;
+    const s = sessions({ store });
+    app.use(s);
+    app.get('/', (req, res) => {
+      req.session.foo = 'foo';
+      res.sendStatus(OK);
+    });
+    return supertest(app)
+      .get('/').expect(200)
+      .then(response => {
+        const cookies = response.headers['set-cookie'];
+        expect(cookies).to.include.match(/connect.sid/);
+        expect(store.sessions).to.not.be.empty;
+      });
+  });
+  it('only initialises sessions when data is stored', () => {
+    const store = new MemoryStore();
+    const app = testApp();
+    expect(store.sessions).to.be.empty;
+    const s = sessions({ store });
+    app.use(s);
+    app.get('/', (req, res) => {
+      res.sendStatus(OK);
+    });
+    return supertest(app)
+      .get('/').expect(200)
+      .then(response => {
+        const cookies = response.headers['set-cookie'];
+        expect(cookies).to.be.undefined;
+        expect(store.sessions).to.be.empty;
+      });
+  });
+});

--- a/test/util/chai.js
+++ b/test/util/chai.js
@@ -1,6 +1,9 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
 
+chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
-module.exports = { expect: chai.expect };
+module.exports = { expect: chai.expect, sinon };

--- a/test/util/supertest.js
+++ b/test/util/supertest.js
@@ -23,7 +23,7 @@ const supertestInstance = stepDSL => {
   if (stepDSL[_supertest]) return stepDSL[_supertest];
 
   const app = testApp();
-  app.use(sessions());
+  app.use(sessions({ baseUrl: '127.0.0.1', secret: 'keyboard cat' }));
   stepDSL[_middleware].forEach(_ => app.use(_));
   app.use(stepDSL.step.router);
   stepDSL[_supertest] = supertest(app);

--- a/test/util/supertest.js
+++ b/test/util/supertest.js
@@ -5,8 +5,6 @@ const nunjucks = require('express-nunjucks');
 
 function testApp() {
   const app = express();
-
-  app.use(sessions());
   app.set('views', ['lib/', 'test/views']);
 
   nunjucks(app, {
@@ -24,7 +22,8 @@ const _middleware = Symbol('middleware');
 const supertestInstance = stepDSL => {
   if (stepDSL[_supertest]) return stepDSL[_supertest];
 
-  const app = testApp(stepDSL.step);
+  const app = testApp();
+  app.use(sessions());
   stepDSL[_middleware].forEach(_ => app.use(_));
   app.use(stepDSL.step.router);
   stepDSL[_supertest] = supertest(app);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@hmcts/eslint-config@^1.0.1":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@hmcts/eslint-config/-/eslint-config-1.0.4.tgz#93b6286cec23f42e25783156a7aae27ece58d6ad"
+"@hmcts/eslint-config@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@hmcts/eslint-config/-/eslint-config-1.0.5.tgz#f992a6f51373d3897847b0c121978e2f136aea83"
 
 a-sync-waterfall@^1.0.0:
   version "1.0.0"
@@ -434,7 +434,7 @@ chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
@@ -557,9 +557,9 @@ concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-config@^1.26.1:
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/config/-/config-1.26.1.tgz#f647ce32c345e80ba73a8eaa7a9a4b4e5b290ca1"
+config@^1.26.2:
+  version "1.26.2"
+  resolved "https://registry.yarnpkg.com/config/-/config-1.26.2.tgz#2466291168d8afae0aae8ab99ea4d4272f520cae"
   dependencies:
     json5 "0.4.0"
     os-homedir "1.0.2"
@@ -776,13 +776,13 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.3.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.4.1.tgz#99cd7eafcffca2ff99a5c8f5f2a474d6364b4bd3"
+eslint@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.5.0.tgz#bb75d3b8bde97fb5e13efcd539744677feb019c3"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"
-    chalk "^1.1.3"
+    chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
     debug "^2.6.8"
@@ -813,6 +813,7 @@ eslint@^4.3.0:
     progress "^2.0.0"
     require-uncached "^1.0.3"
     semver "^5.3.0"
+    strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
     table "^4.0.1"
     text-table "~0.2.0"
@@ -1450,10 +1451,6 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1471,12 +1468,6 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
-
-is-ssh@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.0.tgz#ebea1169a2614da392a63740366c3ce049d8dff6"
-  dependencies:
-    protocols "^1.1.0"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -1976,15 +1967,6 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-url@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
-  dependencies:
-    object-assign "^4.0.1"
-    prepend-http "^1.0.0"
-    query-string "^4.1.0"
-    sort-keys "^1.0.0"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -2167,22 +2149,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-path@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-3.0.1.tgz#355accf0ef1ddd65fec55e694d26dec3d255a421"
-  dependencies:
-    is-ssh "^1.3.0"
-    protocols "^1.4.0"
-
-parse-url@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-3.0.1.tgz#9421fcc995937573548a8af3d7a160b38d955c9d"
-  dependencies:
-    is-ssh "^1.3.0"
-    normalize-url "^1.9.1"
-    parse-path "^3.0.1"
-    protocols "^1.4.0"
-
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
@@ -2273,10 +2239,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prepend-http@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
-
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -2288,10 +2250,6 @@ process-nextick-args@~1.0.6:
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-
-protocols@^1.1.0, protocols@^1.4.0:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.5.tgz#21de1f441c4ef7094408ed9f1c94f7a114b87557"
 
 proxy-addr@~1.1.5:
   version "1.1.5"
@@ -2323,13 +2281,6 @@ qs@6.4.0, qs@~6.4.0:
 qs@6.5.0, qs@^6.1.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
-
-query-string@^4.1.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
-  dependencies:
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
 
 querystringify@~1.0.0:
   version "1.0.0"
@@ -2674,12 +2625,6 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-sort-keys@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
-  dependencies:
-    is-plain-obj "^1.0.0"
-
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -2736,10 +2681,6 @@ sshpk@^1.7.0:
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,13 @@ config@^1.26.1:
     json5 "0.4.0"
     os-homedir "1.0.2"
 
+connect-redis@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.3.0.tgz#c9510c1a567ff710eb2510e6a7509fa92b2232df"
+  dependencies:
+    debug "^2.2.0"
+    redis "^2.1.0"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -709,12 +716,20 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diff@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+
 doctrine@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -963,6 +978,13 @@ filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
@@ -1051,6 +1073,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 formidable@^1.1.1:
   version "1.1.1"
@@ -1402,6 +1430,10 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -1417,6 +1449,10 @@ is-path-inside@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -1436,6 +1472,12 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-ssh@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.0.tgz#ebea1169a2614da392a63740366c3ce049d8dff6"
+  dependencies:
+    protocols "^1.1.0"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -1447,6 +1489,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1588,6 +1634,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -1710,6 +1760,14 @@ log-driver@^1.x:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.1.2.tgz#2694b953c9ea4d013e5b8bfba891c991025b2629"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -1747,7 +1805,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
@@ -1841,6 +1899,10 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
+module-not-found-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+
 moment@2.x.x:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
@@ -1857,6 +1919,10 @@ nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -1864,6 +1930,15 @@ natural-compare@^1.4.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+nise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.0.1.tgz#0da92b10a854e97c0f496f6c2845a301280b3eef"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.22"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
 
 node-pre-gyp@^0.6.36:
   version "0.6.36"
@@ -1900,6 +1975,15 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+normalize-url@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
+  dependencies:
+    object-assign "^4.0.1"
+    prepend-http "^1.0.0"
+    query-string "^4.1.0"
+    sort-keys "^1.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -2083,6 +2167,22 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-path@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-3.0.1.tgz#355accf0ef1ddd65fec55e694d26dec3d255a421"
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
+
+parse-url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-3.0.1.tgz#9421fcc995937573548a8af3d7a160b38d955c9d"
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^1.9.1"
+    parse-path "^3.0.1"
+    protocols "^1.4.0"
+
 parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
@@ -2116,6 +2216,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -2167,6 +2273,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+prepend-http@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -2179,12 +2289,24 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.5.tgz#21de1f441c4ef7094408ed9f1c94f7a114b87557"
+
 proxy-addr@~1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
   dependencies:
     forwarded "~0.1.0"
     ipaddr.js "1.4.0"
+
+proxyquire@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.8.0.tgz#02d514a5bed986f04cbb2093af16741535f79edc"
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.0"
+    resolve "~1.1.7"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -2201,6 +2323,17 @@ qs@6.4.0, qs@~6.4.0:
 qs@6.5.0, qs@^6.1.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
+
+query-string@^4.1.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+querystringify@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -2285,6 +2418,22 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+redis-commands@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
+
+redis-parser@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+
+redis@^2.1.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
+  dependencies:
+    double-ended-queue "^2.1.0-0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.6.0"
+
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
@@ -2365,6 +2514,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+requires-port@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -2372,6 +2525,10 @@ resolve-from@^1.0.0:
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
+resolve@~1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -2423,6 +2580,10 @@ rx-lite@*, rx-lite@^4.0.8:
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
@@ -2481,6 +2642,24 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sinon-chai@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.13.0.tgz#b9a42e801c20234bfc2f43b29e6f4f61b60990c4"
+
+sinon@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-3.2.1.tgz#d8adabd900730fd497788a027049c64b08be91c2"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^2.1.2"
+    native-promise-only "^0.8.1"
+    nise "^1.0.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -2494,6 +2673,12 @@ sntp@1.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
+
+sort-keys@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  dependencies:
+    is-plain-obj "^1.0.0"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -2551,6 +2736,10 @@ sshpk@^1.7.0:
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -2693,6 +2882,10 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2792,6 +2985,13 @@ uid-safe@~2.1.4:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+url-parse@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.1.9.tgz#c67f1d775d51f0a18911dd7b3ffad27bb9e5bd19"
+  dependencies:
+    querystringify "~1.0.0"
+    requires-port "1.0.x"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR adds simple session management using express session, with some extra functionality implemented by shimming the functions on the `req.session` and `req.sessionStore`.

Goals for sessions:
- -Ability to explicitly create a session- - Complete, provided by `req.session.generate()`
- Middleware / Step to create a session - todo
- -Ability to enforce that a session- - Complete, provided by `req.session.active()`
- Middleware to enforce a session - todo
- Middleware / Exit step to destroy a session - todo
- Per record encryption - to do