### PR TITLE
Require session middleware

### DIFF
--- a/examples/test-app/steps/HelloWorld.js
+++ b/examples/test-app/steps/HelloWorld.js
@@ -1,6 +1,9 @@
-const { Page } = require('@hmcts/one-per-page');
+const { Page, middleware } = require('@hmcts/one-per-page');
 
 class HelloWorld extends Page {
+  get middleware() {
+    return [middleware.requireSession, ...super.middleware];
+  }
   get url() {
     return '/hello-world';
   }

--- a/package.json
+++ b/package.json
@@ -29,13 +29,17 @@
     "@hmcts/eslint-config": "^1.0.5",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
+    "chai-jq": "^0.0.9",
     "codacy-coverage": "^2.0.2",
+    "domino": "^1.0.29",
     "eslint": "^4.5.0",
+    "jquery": "^3.2.1",
     "mocha": "^3.4.2",
     "nyc": "^11.1.0",
     "proxyquire": "^1.8.0",
     "sinon": "^3.2.1",
     "sinon-chai": "^2.13.0",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "zepto-node": "^1.0.0"
   }
 }

--- a/src/Journey.js
+++ b/src/Journey.js
@@ -8,7 +8,21 @@ const parseUrl = baseUrl => {
   return urlParse(baseUrl);
 };
 
-const journey = (app, { baseUrl, steps = [], session = {} } = {}) => {
+const journey = (app, {
+  baseUrl,
+  steps = [],
+  session = {},
+  noSessionHandler
+} = {}) => {
+  const setupMiddleware = (req, res, next) => {
+    req.journey = req.journey || {};
+    if (typeof noSessionHandler !== 'undefined') {
+      req.journey.noSessionHandler = noSessionHandler;
+    }
+    next();
+  };
+  app.use(setupMiddleware);
+
   if (typeof session === 'function') {
     app.use(session);
   } else {

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,11 @@
 const BaseStep = require('./steps/BaseStep');
 const Page = require('./steps/Page');
 const journey = require('./Journey');
+const requireSession = require('./middleware/requireSession');
 
 module.exports = {
   Page,
   BaseStep,
-  journey
+  journey,
+  middleware: { requireSession }
 };

--- a/src/middleware/requireSession.js
+++ b/src/middleware/requireSession.js
@@ -1,0 +1,15 @@
+const defaultNoSessionHandler = (req, res) => {
+  res.redirect('/');
+};
+
+const requireSession = (req, res, next) => {
+  if (req.session.active()) {
+    next();
+  } else if (req.journey && req.journey.noSessionHandler) {
+    req.journey.noSessionHandler(req, res, next);
+  } else {
+    defaultNoSessionHandler(req, res, next);
+  }
+};
+
+module.exports = requireSession;

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -45,8 +45,7 @@ const overrides = (req, res, next) => error => {
   res.locals.session = req.session;
 
   if (req.session && req.sessionStore) {
-    req.session.generate = shims.generate(req);
-    req.session.active = shims.active(req);
+    shims.shimSession(req);
     req.sessionStore.set = shims.set(req);
     req.sessionStore.get = shims.get(req);
     req.sessionStore.createSession = shims.createSession(req);

--- a/test/middleware/requireSession.test.js
+++ b/test/middleware/requireSession.test.js
@@ -1,0 +1,43 @@
+const { expect } = require('../util/chai');
+const { testStep } = require('../util/supertest');
+const Page = require('../../src/steps/Page');
+const requireSession = require('../../src/middleware/requireSession');
+
+describe('middleware/requireSession', () => {
+  const page = new class extends Page {
+    get middleware() {
+      return [requireSession, ...super.middleware];
+    }
+    get url() {
+      return '/page';
+    }
+    get template() {
+      return 'page_views/simplePage';
+    }
+  }();
+
+  describe('no session', () => {
+    it('redirects to /', () => {
+      return testStep(page).get().expect(302).expect('Location', '/');
+    });
+
+    it('req.journey.noSessionHandler can override behaviour', () => {
+      const noSessionHandler = (req, res) => res.end('No Session');
+      return testStep(page)
+        .withSetup(req => {
+          req.journey.noSessionHandler = noSessionHandler;
+        })
+        .get()
+        .expect(200, 'No Session');
+    });
+  });
+
+  describe('with session', () => {
+    it('passes through to the steps handler', () => {
+      return testStep(page)
+        .withSetup(req => req.session.generate())
+        .get()
+        .html($ => expect($('h1')).to.have.$text('Hello, World!'));
+    });
+  });
+});

--- a/test/util/chai.js
+++ b/test/util/chai.js
@@ -1,9 +1,11 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const chaiJq = require('chai-jq');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
+chai.use(chaiJq);
 
 module.exports = { expect: chai.expect, sinon };

--- a/test/util/supertest.js
+++ b/test/util/supertest.js
@@ -23,6 +23,13 @@ const supertestInstance = stepDSL => {
   if (stepDSL[_supertest]) return stepDSL[_supertest];
 
   const app = testApp();
+
+  app.use((req, res, next) => {
+    // setup req.journey (added by Journey)
+    req.journey = req.journey || {};
+    next();
+  });
+
   app.use(sessions({ baseUrl: '127.0.0.1', secret: 'keyboard cat' }));
   stepDSL[_middleware].forEach(_ => app.use(_));
   app.use(stepDSL.step.router);
@@ -44,6 +51,13 @@ class TestStepDSL {
   withSession(session) {
     return this.withMiddleware((req, res, next) => {
       req.session = Object.assign(req.session, session);
+      next();
+    });
+  }
+
+  withSetup(setup) {
+    return this.withMiddleware((req, res, next) => {
+      setup(req, res);
       next();
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
 
 accepts@~1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
   dependencies:
-    mime-types "~2.1.11"
+    mime-types "~2.1.16"
     negotiator "0.6.1"
 
 acorn-jsx@^3.0.0:
@@ -211,15 +211,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
-  dependencies:
-    chalk "^1.1.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
-
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -301,8 +293,8 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 binary-extensions@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.9.0.tgz#66506c16ce6f4d6928a5b3cd6a33ca41e941e37b"
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
 
 block-stream@*:
   version "0.0.9"
@@ -413,6 +405,10 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
+chai-jq@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/chai-jq/-/chai-jq-0.0.9.tgz#6df6af3a940cfabafb1ed5184ec7a734d8252882"
+
 chai@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.1.tgz#66e21279e6f3c6415ff8231878227900e2171b39"
@@ -472,8 +468,8 @@ cli-cursor@^2.1.0:
     restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -595,7 +591,7 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-cookiejar@^2.0.6:
+cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
@@ -648,7 +644,7 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.8, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+debug@2.6.8, debug@^2.2.0, debug@^2.6.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -726,6 +722,10 @@ doctrine@^2.0.0:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+domino@^1.0.29:
+  version "1.0.29"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-1.0.29.tgz#de8aa1f6f98e3c5538feb7a61fa69c1eabbace06"
 
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
@@ -1327,8 +1327,8 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
 inquirer@^3.0.6:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.1.tgz#06ceb0f540f45ca548c17d6840959878265fa175"
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.2.tgz#c2aaede1507cc54d826818737742d621bef2e823"
   dependencies:
     ansi-escapes "^2.0.0"
     chalk "^2.0.0"
@@ -1562,6 +1562,10 @@ joi@^6.4.x:
     isemail "1.x.x"
     moment "2.x.x"
     topo "1.x.x"
+
+jquery@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -1832,7 +1836,7 @@ mime-db@~1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
   dependencies:
@@ -1842,7 +1846,7 @@ mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-mime@^1.3.4:
+mime@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
@@ -2278,7 +2282,7 @@ qs@6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-qs@6.5.0, qs@^6.1.0:
+qs@6.5.0, qs@^6.4.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
@@ -2397,8 +2401,8 @@ regex-cache@^0.4.2:
     is-primitive "^2.0.0"
 
 remove-trailing-separator@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -2632,8 +2636,8 @@ source-map@^0.4.4:
     amdefine ">=0.0.4"
 
 source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 spawn-wrap@^1.3.8:
   version "1.3.8"
@@ -2738,18 +2742,18 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 superagent@^3.0.0:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.5.2.tgz#3361a3971567504c351063abeaae0faa23dbf3f8"
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.6.0.tgz#eb679651057c3462199c7b902b696c25350e1b87"
   dependencies:
     component-emitter "^1.2.0"
-    cookiejar "^2.0.6"
-    debug "^2.2.0"
+    cookiejar "^2.1.0"
+    debug "^2.6.0"
     extend "^3.0.0"
     form-data "^2.1.1"
     formidable "^1.1.1"
     methods "^1.1.1"
-    mime "^1.3.4"
-    qs "^6.1.0"
+    mime "^1.3.6"
+    qs "^6.4.0"
     readable-stream "^2.0.5"
 
 supertest@^3.0.0:
@@ -3084,3 +3088,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zepto-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/zepto-node/-/zepto-node-1.0.0.tgz#0da6abbd5fc271ab2a5992f57f09b8c99c3112c3"


### PR DESCRIPTION
This PR implements the requireSession middleware. It is based off of #13 Simple Sessions.

It can be added to a step to enforce a session on that page. By default it redirects to `/` (TODO: should be configurable with some `startpage` property from Journey or infer from which step is of type Start?). You can override the behaviour by providing a `noSessionHandler` to the journey function.

CreateSession and DestroySession can be created using similar approaches.