### PR TITLE
Fields: parsing and storing in the session

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       context: .
     volumes:
       - .:/usr/src/app
+      - ../look-and-feel:/usr/src/look-and-feel
     ports:
       - "9229:9229"
       - "3000:3000"

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -6,6 +6,7 @@ const lookAndFeel = require('@hmcts/look-and-feel');
 const HelloWorld = require('./steps/HelloWorld');
 const CreateSession = require('./steps/CreateSession');
 const Sessions = require('./steps/Sessions');
+const Name = require('./steps/Name');
 
 const app = express();
 
@@ -22,7 +23,8 @@ journey(app, {
   steps: [
     new HelloWorld(),
     new CreateSession(),
-    new Sessions()
+    new Sessions(),
+    new Name()
   ],
   session: {
     redis: { url: config.redisUrl },

--- a/examples/test-app/package.json
+++ b/examples/test-app/package.json
@@ -8,11 +8,12 @@
   },
   "scripts": {
     "start": "node app.js",
-    "start-dev": "node-dev app.js"
+    "start-dev": "node-dev --inspect=0.0.0.0:9229 app.js"
   },
   "dependencies": {
-    "@hmcts/look-and-feel": "^0.2.0",
+    "@hmcts/look-and-feel": "./../../../look-and-feel",
     "@hmcts/one-per-page": "./../../",
+    "copy-webpack-plugin": "^4.0.1",
     "express": "^4.15.3"
   },
   "devDependencies": {

--- a/examples/test-app/steps/CreateSession.js
+++ b/examples/test-app/steps/CreateSession.js
@@ -8,6 +8,8 @@ class CreateSession extends Page {
   handler(req, res) {
     req.session.generate();
     req.session.username = 'Michael';
+    req.session.Name_firstName = 'Michael';
+    req.session.Name_lastName = 'Allen';
     res.redirect('/sessions');
   }
 }

--- a/examples/test-app/steps/HelloWorld.js
+++ b/examples/test-app/steps/HelloWorld.js
@@ -1,9 +1,6 @@
-const { Page, middleware } = require('@hmcts/one-per-page');
+const { Page } = require('@hmcts/one-per-page');
 
 class HelloWorld extends Page {
-  get middleware() {
-    return [middleware.requireSession, ...super.middleware];
-  }
   get url() {
     return '/hello-world';
   }

--- a/examples/test-app/steps/Name.js
+++ b/examples/test-app/steps/Name.js
@@ -1,12 +1,15 @@
-const { Question, field } = require('@hmcts/one-per-page');
+const { Question, field, form } = require('@hmcts/one-per-page');
 
 class Name extends Question {
   get url() {
     return '/name';
   }
 
-  get fields() {
-    return [field('firstName'), field('lastName')];
+  get form() {
+    return form(
+      field('firstName'),
+      field('lastName')
+    );
   }
 }
 

--- a/examples/test-app/steps/Name.js
+++ b/examples/test-app/steps/Name.js
@@ -1,0 +1,13 @@
+const { Question, field } = require('@hmcts/one-per-page');
+
+class Name extends Question {
+  get url() {
+    return '/name';
+  }
+
+  get fields() {
+    return [field('firstName'), field('lastName')];
+  }
+}
+
+module.exports = Name;

--- a/examples/test-app/views/Name.html
+++ b/examples/test-app/views/Name.html
@@ -1,0 +1,22 @@
+{% extends "look-and-feel/layouts/question.html" %}
+{% from "look-and-feel/components/header.njk" import header %}
+{% from "look-and-feel/components/fields.njk" import textbox, formSection %}
+
+{% set phase="ALPHA" %}
+{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
+{% set title %}
+  What is your name?
+{% endset %}
+
+{% block head -%}
+<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
+{% endblock %}
+
+{% block fields %}
+
+  {% call formSection() %}
+    {{ textbox(fields.firstName, "First name(s)", hint="Include all middle names here") }}
+    {{ textbox(fields.lastName, "Last name(s)") }}
+  {% endcall %}
+
+{% endblock %}

--- a/examples/test-app/yarn.lock
+++ b/examples/test-app/yarn.lock
@@ -2,9 +2,8 @@
 # yarn lockfile v1
 
 
-"@hmcts/look-and-feel@^0.2.0":
+"@hmcts/look-and-feel@./../../../look-and-feel":
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-0.2.0.tgz#7a3e9261a60d313bb4a09884110fa54a430118e5"
   dependencies:
     check-types "^7.3.0"
     config "^1.26.1"
@@ -28,14 +27,17 @@
   version "0.0.1"
   dependencies:
     body-parser "^1.17.2"
-    config "^1.26.1"
+    config "^1.26.2"
+    connect-redis "^3.3.0"
     express "^4.15.3"
     express-nunjucks "^2.2.3"
     express-session "^1.15.4"
     http-status-codes "^1.2.0"
     js-yaml "^3.9.0"
     nunjucks "^3.0.1"
+    option "^0.2.4"
     router "^1.3.1"
+    url-parse "^1.1.9"
 
 a-sync-waterfall@^1.0.0:
   version "1.0.0"
@@ -633,12 +635,19 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-config@^1.26.1:
+config@^1.26.1, config@^1.26.2:
   version "1.26.2"
   resolved "https://registry.yarnpkg.com/config/-/config-1.26.2.tgz#2466291168d8afae0aae8ab99ea4d4272f520cae"
   dependencies:
     json5 "0.4.0"
     os-homedir "1.0.2"
+
+connect-redis@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.3.0.tgz#c9510c1a567ff710eb2510e6a7509fa92b2232df"
+  dependencies:
+    debug "^2.2.0"
+    redis "^2.1.0"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -928,6 +937,10 @@ diffie-hellman@^5.0.0:
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
 
 dynamic-dedupe@^0.2.0:
   version "0.2.0"
@@ -2469,6 +2482,10 @@ once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
+option@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/option/-/option-0.2.4.tgz#fd475cdf98dcabb3cb397a3ba5284feb45edbfe4"
+
 os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
@@ -2947,6 +2964,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+querystringify@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
 random-bytes@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
@@ -3049,6 +3070,22 @@ redeyed@~1.0.0:
   dependencies:
     esprima "~3.0.0"
 
+redis-commands@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
+
+redis-parser@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+
+redis@^2.1.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
+  dependencies:
+    double-ended-queue "^2.1.0-0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.6.0"
+
 reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
@@ -3144,6 +3181,10 @@ require-directory@^2.1.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+requires-port@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 resolve@^1.0.0:
   version "1.4.0"
@@ -3617,6 +3658,13 @@ uniqs@^2.0.0:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+url-parse@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.1.9.tgz#c67f1d775d51f0a18911dd7b3ffad27bb9e5bd19"
+  dependencies:
+    querystringify "~1.0.0"
+    requires-port "1.0.x"
 
 url@^0.11.0:
   version "0.11.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "http-status-codes": "^1.2.0",
     "js-yaml": "^3.9.0",
     "nunjucks": "^3.0.1",
+    "option": "^0.2.4",
     "router": "^1.3.1",
     "url-parse": "^1.1.9"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ const journey = require('./Journey');
 const requireSession = require('./middleware/requireSession');
 const parseRequest = require('./middleware/parseRequest');
 
-const { field } = require('./services/fields');
+const { field, form } = require('./services/fields');
 
 module.exports = {
   BaseStep,
@@ -15,5 +15,6 @@ module.exports = {
   Question,
   journey,
   middleware: { requireSession, parseRequest },
-  field
+  field,
+  form
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,19 @@
 const BaseStep = require('./steps/BaseStep');
 const Page = require('./steps/Page');
+const Question = require('./steps/Question');
+
 const journey = require('./Journey');
+
 const requireSession = require('./middleware/requireSession');
+const parseRequest = require('./middleware/parseRequest');
+
+const { field } = require('./services/fields');
 
 module.exports = {
-  Page,
   BaseStep,
+  Page,
+  Question,
   journey,
-  middleware: { requireSession }
+  middleware: { requireSession, parseRequest },
+  field
 };

--- a/src/middleware/addLocals.js
+++ b/src/middleware/addLocals.js
@@ -1,0 +1,7 @@
+const addLocals = (req, res, next) => {
+  res.locals = res.locals || {};
+  res.locals.url = req.currentStep.url;
+  next();
+};
+
+module.exports = addLocals;

--- a/src/middleware/parseRequest.js
+++ b/src/middleware/parseRequest.js
@@ -1,5 +1,7 @@
 const parseRequest = (req, res, next) => {
   req.fields = req.fields || {};
+  res.locals = res.locals || {};
+  res.locals.fields = req.fields;
 
   const fieldsToParse = req.currentStep.fields || [];
   fieldsToParse.forEach(field => {

--- a/src/middleware/parseRequest.js
+++ b/src/middleware/parseRequest.js
@@ -17,13 +17,23 @@ const parseRequest = (req, res, next) => {
     return;
   }
   const form = req.currentStep.form;
-  const parsedFields = form.parse(req);
 
-  parsedFields.forEach(field => {
-    req.fields[field.name] = field;
-  });
+  if (req.method === 'POST') {
+    const parsedFields = form.parse(req);
+
+    parsedFields.forEach(field => {
+      req.fields[field.name] = field;
+    });
+  } else if (req.method === 'GET') {
+    const retrievedFields = form.retrieve(req);
+
+    retrievedFields.forEach(field => {
+      req.fields[field.name] = field;
+    });
+  }
 
   defineNotEnumberable(req.fields, 'validate', () => form.validate(req.fields));
+  defineNotEnumberable(req.fields, 'store', () => form.store(req));
   defineNotEnumberable(req.fields, 'errors', () => form.errors(req.fields));
   defineNotEnumberable(req.fields, 'valid', () => form.valid(req.fields));
 

--- a/src/middleware/parseRequest.js
+++ b/src/middleware/parseRequest.js
@@ -2,7 +2,10 @@ const parseRequest = (req, res, next) => {
   req.fields = req.fields || {};
 
   const fieldsToParse = req.currentStep.fields || [];
-  fieldsToParse.forEach(field => field.parse(req));
+  fieldsToParse.forEach(field => {
+    const parsedField = field.parse(req);
+    req.fields[parsedField.name] = parsedField;
+  });
 
   next();
 };

--- a/src/middleware/parseRequest.js
+++ b/src/middleware/parseRequest.js
@@ -1,0 +1,10 @@
+const parseRequest = (req, res, next) => {
+  req.fields = req.fields || {};
+
+  const fieldsToParse = req.currentStep.fields || [];
+  fieldsToParse.forEach(field => field.parse(req));
+
+  next();
+};
+
+module.exports = parseRequest;

--- a/src/services/fields.js
+++ b/src/services/fields.js
@@ -5,10 +5,23 @@ class Form {
     this.fields = fields;
   }
 
+  /**
+   * Parses the fields described in the form from the request body
+   * Used on POST requests.
+   *
+   * @param {object} req - the express request
+   * @return {list} fields - the parsed fields containing their values
+   */
   parse(req) {
     return this.fields.map(field => field.parse(req));
   }
 
+  /**
+   * Stores the fields described in the form to the session by querying their
+   * parsed values in request.fields
+   *
+   * @param {object} req - the express request
+   */
   store(req) {
     if (typeof req.session === 'undefined') {
       throw new Error('Session not initialized');
@@ -23,6 +36,13 @@ class Form {
     });
   }
 
+  /**
+   * Loads the fields described in the form from the session.
+   * Used on GET requests to prepopulate fields with existing values.
+   *
+   * @param {object} req - the express request
+   * @return {list} fields - the populated fields containing their values
+   */
   retrieve(req) {
     return this.fields.map(field => field.deserialize(req));
   }
@@ -47,6 +67,13 @@ class FieldDesriptor {
     this.value = value;
   }
 
+  /**
+   * Parses the request body looking for a parameter with the same name
+   * as this field.
+   *
+   * @param {object} req - the express request
+   * @return {FieldDescriptor} field - the parsed field filled with it's value
+   */
   parse(req) {
     const id = this.makeId(req.currentStep);
 
@@ -58,6 +85,12 @@ class FieldDesriptor {
     return new FieldDesriptor(this.name, id, value);
   }
 
+  /**
+   * Deserializes this field from the session
+   *
+   * @param {object} req - the express request
+   * @return {FieldDescriptor} field - the loaded field filled with it's value
+   */
   deserialize(req) {
     const id = this.makeId(req.currentStep);
 
@@ -69,6 +102,12 @@ class FieldDesriptor {
     return new FieldDesriptor(this.name, id, value);
   }
 
+  /**
+   * Serializes the field in to format to be stored in the session
+   *
+   * @return {{ [field id]: [field value] }} - the values to be store in the
+   *   session
+   */
   serialize() {
     if (typeof this.id === 'undefined') return {};
     if (typeof this.value === 'undefined') return {};

--- a/src/services/fields.js
+++ b/src/services/fields.js
@@ -1,0 +1,19 @@
+class Field {
+  constructor(name, value) {
+    this.name = name;
+    this.value = value;
+  }
+}
+
+class FieldDesriptor {
+  constructor(name) {
+    this.name = name;
+  }
+  parse(req) {
+    req.fields[this.name] = new Field(this.name, '');
+  }
+}
+
+const field = name => new FieldDesriptor(name);
+
+module.exports = { field, FieldDesriptor };

--- a/src/services/fields.js
+++ b/src/services/fields.js
@@ -1,6 +1,9 @@
+const option = require('option');
+
 class ParsedField {
-  constructor(name, value) {
+  constructor(name, id, value) {
     this.name = name;
+    this.id = id;
     this.value = value;
   }
 }
@@ -9,8 +12,29 @@ class FieldDesriptor {
   constructor(name) {
     this.name = name;
   }
-  parse(/* req */) {
-    return new ParsedField(this.name, '');
+
+  parse(req) {
+    const id = this.makeId(req.currentStep);
+
+    const valueFromSession = option
+      .fromNullable(req.session)
+      .map(session => session[id]);
+
+    const valueFromBody = option
+      .fromNullable(req.body)
+      .map(body => body[id]);
+
+    const value = valueFromBody
+      .orElse(valueFromSession)
+      .valueOrElse('');
+    return new ParsedField(this.name, id, value);
+  }
+
+  makeId(step) {
+    if (typeof step === 'undefined' || typeof step.name === 'undefined') {
+      return this.name;
+    }
+    return `${step.name}_${this.name}`;
   }
 }
 

--- a/src/services/fields.js
+++ b/src/services/fields.js
@@ -1,5 +1,31 @@
 const option = require('option');
 
+class Form {
+  constructor(fields = []) {
+    this.fields = fields;
+  }
+
+  parse(req) {
+    return this.fields.map(field => field.parse(req));
+  }
+
+  validate(/* parsedFields */) {
+    /* intentionally blank */
+  }
+
+  errors(/* parsedFields */) {
+    // placeholder for now
+    return [];
+  }
+
+  valid(/* parsedFields */) {
+    // placeholder for now
+    return true;
+  }
+}
+
+const form = (...fields) => new Form(fields);
+
 class ParsedField {
   constructor(name, id, value) {
     this.name = name;
@@ -18,15 +44,16 @@ class FieldDesriptor {
 
     const valueFromSession = option
       .fromNullable(req.session)
-      .map(session => session[id]);
+      .flatMap(session => option.fromNullable(session[id]));
 
     const valueFromBody = option
       .fromNullable(req.body)
-      .map(body => body[id]);
+      .flatMap(body => option.fromNullable(body[id]));
 
     const value = valueFromBody
       .orElse(valueFromSession)
       .valueOrElse('');
+
     return new ParsedField(this.name, id, value);
   }
 
@@ -38,6 +65,6 @@ class FieldDesriptor {
   }
 }
 
-const field = name => new FieldDesriptor(name);
+const field = (name, validator) => new FieldDesriptor(name, validator);
 
-module.exports = { field, FieldDesriptor, ParsedField };
+module.exports = { field, FieldDesriptor, ParsedField, form, Form };

--- a/src/services/fields.js
+++ b/src/services/fields.js
@@ -1,4 +1,4 @@
-class Field {
+class ParsedField {
   constructor(name, value) {
     this.name = name;
     this.value = value;
@@ -9,11 +9,11 @@ class FieldDesriptor {
   constructor(name) {
     this.name = name;
   }
-  parse(req) {
-    req.fields[this.name] = new Field(this.name, '');
+  parse(/* req */) {
+    return new ParsedField(this.name, '');
   }
 }
 
 const field = name => new FieldDesriptor(name);
 
-module.exports = { field, FieldDesriptor };
+module.exports = { field, FieldDesriptor, ParsedField };

--- a/src/steps/BaseStep.js
+++ b/src/steps/BaseStep.js
@@ -1,6 +1,11 @@
 const { Router: expressRouter } = require('express');
 const { expectImplemented } = require('../errors/expectImplemented');
 
+const bindToReq = (_this, property) => (req, res, next) => {
+  req[property] = _this;
+  next();
+};
+
 class BaseStep {
   constructor() {
     expectImplemented(this, 'url', 'handler');
@@ -16,6 +21,7 @@ class BaseStep {
     if (this._router) return this._router;
 
     this._router = expressRouter();
+    this._router.use(this.url, bindToReq(this, 'currentStep'));
     this.middleware.forEach(middleware => {
       this._router.use(this.url, middleware.bind(this));
     });

--- a/src/steps/Page.js
+++ b/src/steps/Page.js
@@ -1,7 +1,12 @@
 const BaseStep = require('./BaseStep');
+const addLocals = require('../middleware/addLocals');
 const { METHOD_NOT_ALLOWED } = require('http-status-codes');
 
 class Page extends BaseStep {
+  get middleware() {
+    return [addLocals];
+  }
+
   get template() {
     return this.name;
   }

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -1,0 +1,22 @@
+const BaseStep = require('./BaseStep');
+const requireSession = require('./../middleware/requireSession');
+
+class Question extends BaseStep {
+  get middleware() {
+    return [requireSession];
+  }
+
+  get template() {
+    return this.name;
+  }
+
+  handler(req, res) {
+    if (req.method === 'GET') {
+      res.render(this.template);
+    } else {
+      // handle post
+    }
+  }
+}
+
+module.exports = Question;

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -1,11 +1,13 @@
 const Page = require('./Page');
 const requireSession = require('./../middleware/requireSession');
 const parseRequest = require('../middleware/parseRequest');
+const bodyParser = require('body-parser');
 
 class Question extends Page {
   get middleware() {
     return [
       ...super.middleware,
+      bodyParser.urlencoded({ extended: true }),
       requireSession,
       parseRequest
     ];
@@ -19,6 +21,8 @@ class Question extends Page {
     if (req.method === 'GET') {
       super.handler(req, res);
     } else {
+      if (this.fields.valid())
+      res.end();
       // handle post
     }
   }

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -1,9 +1,14 @@
-const BaseStep = require('./BaseStep');
+const Page = require('./Page');
 const requireSession = require('./../middleware/requireSession');
+const parseRequest = require('../middleware/parseRequest');
 
-class Question extends BaseStep {
+class Question extends Page {
   get middleware() {
-    return [requireSession];
+    return [
+      ...super.middleware,
+      requireSession,
+      parseRequest
+    ];
   }
 
   get template() {
@@ -12,7 +17,7 @@ class Question extends BaseStep {
 
   handler(req, res) {
     if (req.method === 'GET') {
-      res.render(this.template);
+      super.handler(req, res);
     } else {
       // handle post
     }

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -21,7 +21,9 @@ class Question extends Page {
     if (req.method === 'GET') {
       super.handler(req, res);
     } else {
-      if (this.fields.valid())
+      if (this.fields.valid()) {
+        this.fields.store();
+      }
       res.end();
       // handle post
     }

--- a/test/middleware/parseRequest.test.js
+++ b/test/middleware/parseRequest.test.js
@@ -4,7 +4,7 @@ const Page = require('../../src/steps/Page');
 const parseRequest = require('../../src/middleware/parseRequest');
 const { field, form } = require('../../src/services/fields.js');
 
-const handlerTest = (_form, assertions) => {
+const handlerTest = (_form, { method = 'get', assertions }) => {
   const _step = new class extends Page {
     get middleware() {
       return [parseRequest];
@@ -20,33 +20,41 @@ const handlerTest = (_form, assertions) => {
       res.end();
     }
   }();
-  return testStep(_step).get().expect(200);
+  return testStep(_step).execute(method).expect(200);
 };
 
 describe('middleware/parseRequest', () => {
   it('attaches an Object to req.fields', () => {
-    return handlerTest(form(), req => {
-      expect(req).to.have.property('fields');
-      expect(req.fields).to.be.an('object');
+    return handlerTest(form(), {
+      assertions(req) {
+        expect(req).to.have.property('fields');
+        expect(req.fields).to.be.an('object');
+      }
     });
   });
 
-  it('attaches a ParsedField for each field to req.fields.[name]', () => {
-    return handlerTest(form(field('foo'), field('bar')), req => {
-      expect(req.fields).to.have.property('foo');
-      expect(req.fields).to.have.property('bar');
+  it('attaches a FieldDesriptor for each field to req.fields.[name]', () => {
+    return handlerTest(form(field('foo'), field('bar')), {
+      assertions(req) {
+        expect(req.fields).to.have.property('foo');
+        expect(req.fields).to.have.property('bar');
+      }
     });
   });
 
   it('attaches #valid to req.fields', () => {
-    return handlerTest(form(), req => {
-      expect(req.fields.validate).to.be.a('function');
+    return handlerTest(form(), {
+      assertions(req) {
+        expect(req.fields.validate).to.be.a('function');
+      }
     });
   });
 
   it('attaches req.fields to the currentStep (this in handler)', () => {
-    return handlerTest(form(field('foo'), field('bar')), req => {
-      expect(req.currentStep.fields).to.eql(req.fields);
+    return handlerTest(form(field('foo'), field('bar')), {
+      assertions(req) {
+        expect(req.currentStep.fields).to.eql(req.fields);
+      }
     });
   });
 
@@ -71,18 +79,38 @@ describe('middleware/parseRequest', () => {
 
 
     it('has a field for each declared field', () => {
-      return handlerTest(form(field('foo'), field('bar')), req => {
-        expect(req.fields).to.have.keys(['foo', 'bar']);
+      return handlerTest(form(field('foo'), field('bar')), {
+        assertions(req) {
+          expect(req.fields).to.have.keys(['foo', 'bar']);
+        }
       });
     });
 
-    it('calls #parse for each field', () => {
-      const fakeField = field('fake');
-      sinon.spy(fakeField, 'parse');
-      return handlerTest(form(fakeField), req => {
-        expect(req.fields).to.have.key('fake');
-        expect(req.fields.fake).to.have.property('name', 'fake');
-      }).then(() => expect(fakeField.parse).calledOnce);
+    describe('GET', () => {
+      it('calls #deserialize for each field', () => {
+        const fakeField = field('fake');
+        sinon.spy(fakeField, 'deserialize');
+        return handlerTest(form(fakeField), {
+          assertions(req) {
+            expect(req.fields).to.have.key('fake');
+            expect(req.fields.fake).to.have.property('name', 'fake');
+          }
+        }).then(() => expect(fakeField.deserialize).calledOnce);
+      });
+    });
+
+    describe('POST', () => {
+      it('calls #parse for each field', () => {
+        const fakeField = field('fake');
+        sinon.spy(fakeField, 'parse');
+        return handlerTest(form(fakeField), {
+          method: 'post',
+          assertions(req) {
+            expect(req.fields).to.have.key('fake');
+            expect(req.fields.fake).to.have.property('name', 'fake');
+          }
+        }).then(() => expect(fakeField.parse).calledOnce);
+      });
     });
   });
 });

--- a/test/middleware/parseRequest.test.js
+++ b/test/middleware/parseRequest.test.js
@@ -1,0 +1,77 @@
+const { expect, sinon } = require('../util/chai');
+const { testStep } = require('../util/supertest');
+const Page = require('../../src/steps/Page');
+const parseRequest = require('../../src/middleware/parseRequest');
+const { field } = require('../../src/services/fields.js');
+
+const handlerTest = ({ handler, fields }) => {
+  const _step = new class extends Page {
+    get middleware() {
+      return [parseRequest];
+    }
+    get url() {
+      return '/test';
+    }
+    get fields() {
+      return fields;
+    }
+    handler(req, res) {
+      handler(req, res);
+      res.end();
+    }
+  }();
+  return testStep(_step).get().expect(200);
+};
+
+describe('middleware/parseRequest', () => {
+  describe('req.fields', () => {
+    it('is empty if step.fields is empty', () => {
+      return handlerTest({
+        fields: [],
+        handler(req) {
+          expect(req.fields).to.be.an('object');
+          expect(req.fields).to.be.empty;
+        }
+      });
+    });
+
+    it('is empty if step.fields is not defined', () => {
+      const step = new class extends Page {
+        get middleware() {
+          return [parseRequest];
+        }
+        get url() {
+          return '/test';
+        }
+        handler(req, res) {
+          expect(req.fields).to.be.an('object');
+          expect(req.fields).to.be.empty;
+          res.end();
+        }
+      }();
+
+      return testStep(step).get().expect(200);
+    });
+
+    it('has a field for each declared field', () => {
+      return handlerTest({
+        fields: [field('foo'), field('bar')],
+        handler(req) {
+          expect(req.fields).to.have.keys(['foo', 'bar']);
+        }
+      });
+    });
+
+    it('calls #parse for each field', () => {
+      const fakeField = field('fake');
+      sinon.spy(fakeField, 'parse');
+      return handlerTest({
+        fields: [fakeField],
+        handler(req) {
+          expect(req.fields).to.have.key('fake');
+          expect(req.fields.fake).to.have.property('name', 'fake');
+        }
+      }).then(() => expect(fakeField.parse).calledOnce);
+    });
+  });
+});

--- a/test/services/fields.test.js
+++ b/test/services/fields.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('../util/chai');
+const {
+  field,
+  FieldDesriptor,
+  ParsedField
+} = require('../../src/services/fields');
+
+describe('services/fields', () => {
+  describe('#field', () => {
+    it('returns a FieldDesriptor', () => {
+      const foo = field('foo');
+      expect(foo).to.be.an.instanceof(FieldDesriptor);
+    });
+  });
+
+  describe('FieldDesriptor', () => {
+    it('stores its name', () => {
+      const f = new FieldDesriptor('my name');
+      expect(f).to.have.property('name', 'my name');
+    });
+
+    describe('#parse', () => {
+      it('returns a ParsedField', () => {
+        const foo = new FieldDesriptor('first_name', 'Michael');
+        expect(foo.parse({})).to.be.an.instanceof(ParsedField);
+      });
+    });
+  });
+
+  describe('ParsedField', () => {
+    it('stores name and parsed value', () => {
+      const f = new ParsedField('my name', 'my value');
+      expect(f).to.have.property('name', 'my name');
+      expect(f).to.have.property('value', 'my value');
+    });
+  });
+});

--- a/test/services/fields.test.js
+++ b/test/services/fields.test.js
@@ -21,16 +21,58 @@ describe('services/fields', () => {
 
     describe('#parse', () => {
       it('returns a ParsedField', () => {
-        const foo = new FieldDesriptor('first_name', 'Michael');
+        const foo = new FieldDesriptor('first_name');
         expect(foo.parse({})).to.be.an.instanceof(ParsedField);
+      });
+
+      it('fills ParsedField.value with answer from the session', () => {
+        const req = {
+          session: { NameStep_firstName: 'Michael' },
+          currentStep: { name: 'NameStep' }
+        };
+        const firstName = new FieldDesriptor('firstName');
+        expect(firstName.parse(req)).to.have.property('value', 'Michael');
+      });
+
+      it('fills ParsedField.value with answer from request body', () => {
+        const req = {
+          body: { NameStep_firstName: 'Michael' },
+          currentStep: { name: 'NameStep' }
+        };
+        const firstName = new FieldDesriptor('firstName');
+        expect(firstName.parse(req)).to.have.property('value', 'Michael');
+      });
+
+      it('prefers answer from request body over session', () => {
+        const req = {
+          body: { NameStep_firstName: 'Michael' },
+          session: { NameStep_firstName: 'John' },
+          currentStep: { name: 'NameStep' }
+        };
+        const firstName = new FieldDesriptor('firstName');
+        expect(firstName.parse(req)).to.have.property('value', 'Michael');
+      });
+    });
+
+    describe('#makeId', () => {
+      it('returns the FieldDesriptors name if step is undefined', () => {
+        const foo = new FieldDesriptor('first_name', 'Michael');
+        expect(foo.makeId()).to.eql(foo.name);
+      });
+
+      it('returns an id based on the fields name and step', () => {
+        const foo = new FieldDesriptor('first_name', 'Michael');
+        const fakeStep = { name: 'NameStep' };
+        expect(foo.makeId(fakeStep)).to.eql(`${fakeStep.name}_${foo.name}`);
       });
     });
   });
 
   describe('ParsedField', () => {
-    it('stores name and parsed value', () => {
-      const f = new ParsedField('my name', 'my value');
-      expect(f).to.have.property('name', 'my name');
+    it('stores name, id and parsed value', () => {
+      const f = new ParsedField('my_name', 'my_id', 'my value');
+      expect(f).to.have.property('name', 'my_name');
+      expect(f).to.have.property('id', 'my_id');
       expect(f).to.have.property('value', 'my value');
     });
   });

--- a/test/steps/BaseStep.test.js
+++ b/test/steps/BaseStep.test.js
@@ -5,7 +5,7 @@ const { expect } = require('../util/chai');
 
 const { NotImplemented } = require('../../src/errors/expectImplemented');
 
-describe('Step', () => {
+describe('steps/BaseStep', () => {
   {
     const unimplementedStep = () => new class extends BaseStep {}();
 
@@ -53,6 +53,19 @@ describe('Step', () => {
       }();
       return testStep(step).get()
         .expect(OK, { status: 'ok', url: step.url });
+    });
+
+    it('binds the current step to req.currentStep', () => {
+      const test = new class extends BaseStep {
+        get url() {
+          return '/test';
+        }
+        handler(req, res) {
+          expect(req.currentStep).to.eql(this);
+          res.end();
+        }
+      }();
+      return testStep(test).get().expect(OK);
     });
   });
 

--- a/test/steps/Question.test.js
+++ b/test/steps/Question.test.js
@@ -1,0 +1,40 @@
+const { expect } = require('../util/chai');
+const { testStep } = require('../util/supertest');
+const Question = require('../../src/steps/Question');
+const { NotImplemented } = require('../../src/errors/expectImplemented');
+
+describe('steps/Question', () => {
+  {
+    const unimplementedQuestion = () => {
+      return new class extends Question {}();
+    };
+
+    it('expects url to be implemented', () => {
+      return expect(unimplementedQuestion)
+        .to.throw(NotImplemented)
+        .that.has.property('unimplemented').which.contains('url');
+    });
+  }
+
+  {
+    const question = new class extends Question {
+      get url() {
+        return '/question-1';
+      }
+      get template() {
+        return 'question_views/simpleQuestion';
+      }
+    }();
+
+    describe('GET', () => {
+      it('renders the page on GET', () => {
+        return testStep(question)
+          .withSetup(req => req.session.generate())
+          .get()
+          .html($ => {
+            return expect($('h1')).to.contain.$text('Question 1');
+          });
+      });
+    });
+  }
+});

--- a/test/steps/Question.test.js
+++ b/test/steps/Question.test.js
@@ -2,6 +2,7 @@ const { expect } = require('../util/chai');
 const { testStep } = require('../util/supertest');
 const Question = require('../../src/steps/Question');
 const { NotImplemented } = require('../../src/errors/expectImplemented');
+const { field, form } = require('../../src/services/fields');
 
 describe('steps/Question', () => {
   {
@@ -18,6 +19,9 @@ describe('steps/Question', () => {
 
   {
     const question = new class extends Question {
+      get form() {
+        return form(field('name'));
+      }
       get url() {
         return '/question-1';
       }
@@ -33,6 +37,18 @@ describe('steps/Question', () => {
           .get()
           .html($ => {
             return expect($('h1')).to.contain.$text('Question 1');
+          });
+      });
+
+      it('loads fields from the session', () => {
+        return testStep(question)
+          .withSetup(req => {
+            req.session.generate();
+            req.session.Question_name = 'Michael Allen';
+          })
+          .get()
+          .html($ => {
+            expect($('#Question_name')).to.contain.$val('Michael Allen');
           });
       });
     });

--- a/test/steps/Question.test.js
+++ b/test/steps/Question.test.js
@@ -52,5 +52,17 @@ describe('steps/Question', () => {
           });
       });
     });
+
+    describe('POST', () => {
+      it('saves answers in the session', () => {
+        return testStep(question)
+          .withSetup(req => req.session.generate())
+          .withField('name', 'Michael Allen')
+          .post()
+          .session(session => {
+            expect(session).to.contain.key('Question_name');
+          });
+      });
+    });
   }
 });

--- a/test/views/question_views/simpleQuestion.html
+++ b/test/views/question_views/simpleQuestion.html
@@ -1,0 +1,1 @@
+<h1>Question 1</h1>

--- a/test/views/question_views/simpleQuestion.html
+++ b/test/views/question_views/simpleQuestion.html
@@ -1,1 +1,9 @@
 <h1>Question 1</h1>
+
+<div>
+  {{ fields.name }}
+  <input name="{{ fields.name.name }}"
+         value="{{ fields.name.value }}"
+         id="{{ fields.name.id }}"
+         type="text">
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,6 +2084,10 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
+option@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/option/-/option-0.2.4.tgz#fd475cdf98dcabb3cb397a3ba5284feb45edbfe4"
+
 optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"


### PR DESCRIPTION
This PR implements a method of declaring specific fields to be parsed and available for validation.

You declare the fields on your Question as so:

```
class Name extends Question {
  ...
  get form() {
    return form(
      field('firstName'),
      field('lastName')
    );
  }
}
```

These would then be available on the template to render, each with a `.id`, `.name`, `.value`:

```
<form>
  <input type="textbox"
         id="{{fields.firstName.id}}"
         name="{{fields.firstName.name}}"
         value="{{fields.firstName.value}}">
</form>
```

For convenience we are building some helpers in https://github.com/hmcts/look-and-feel that use this field structure:
```
{% from "look-and-feel/components/fields.njk" import textbox %}

<form>
    {{ textbox(fields.firstName, "First name(s)", hint="Include all middle names here") }}
</form>

```