### PR TITLE
Fix linting issues introduced in recent PRs

### DIFF
--- a/examples/test-app/steps/Country/index.js
+++ b/examples/test-app/steps/Country/index.js
@@ -36,4 +36,3 @@ class Country extends Question {
 }
 
 module.exports = Country;
-

--- a/src/util/walkMap.js
+++ b/src/util/walkMap.js
@@ -1,3 +1,7 @@
+// This file will soon be removed. To save time, for now, I am ignoring linting.
+
+/* eslint-disable */
+
 /* Walk map loops through each item in array or object returning a
  * to the item. For example an object like:
  * const obj = { foo: { bar: 'bar', bar2: 'bar2'} }

--- a/test/middleware/applyContent.test.js
+++ b/test/middleware/applyContent.test.js
@@ -4,7 +4,7 @@ const applyContent = require('../../src/middleware/applyContent');
 describe('middleware/applyContent', () => {
   it('sets current steps content to res.locals', () => {
     const content = { title: 'some title' };
-    const req = { currentStep: { content: content } };
+    const req = { currentStep: { content } };
     const res = {};
     const next = sinon.stub();
     applyContent(req, res, next);

--- a/test/middleware/destroySession.test.js
+++ b/test/middleware/destroySession.test.js
@@ -2,21 +2,21 @@ const { expect, sinon } = require('../util/chai');
 const destroySession = require('../../src/middleware/destroySession');
 
 describe('middleware/destroySession', () => {
-  
   it('calls req.session.destroy() to destroy a session', done => {
     const req = { session: { destroy: sinon.stub() } };
-    const assertions = () => {
+    const res = {};
+    const next = () => {
       expect(req.session.destroy).calledOnce;
       done();
     };
 
-    destroySession(req, {}, assertions);
+    destroySession(req, res, next);
   });
 
   describe('#session', () => {
-    it('throws an error if session is not initialized', done => {
-      expect(() => destroySession({}, {}, {})).to.throw('Session not initialized');
-      done();
+    it('throws an error if session is not initialized', () => {
+      const noSessionInReq = () => destroySession({}, {}, {});
+      expect(noSessionInReq).to.throw('Session not initialized');
     });
   });
 });

--- a/test/middleware/parseRequest.test.js
+++ b/test/middleware/parseRequest.test.js
@@ -2,7 +2,12 @@ const { expect, sinon } = require('../util/chai');
 const { testStep } = require('../util/supertest');
 const Page = require('../../src/steps/Page');
 const parseRequest = require('../../src/middleware/parseRequest');
-const { field, form, Form, FieldDesriptor } = require('../../src/services/fields.js');
+const {
+  field,
+  form,
+  Form,
+  FieldDesriptor
+} = require('../../src/services/fields.js');
 
 const handlerTest = (_form, { method = 'get', assertions }) => {
   const _step = new class extends Page {

--- a/test/services/fields.test.js
+++ b/test/services/fields.test.js
@@ -1,3 +1,4 @@
+/* eslint max-lines: 0 */
 const { expect, sinon } = require('../util/chai');
 const {
   field,
@@ -166,7 +167,6 @@ describe('services/fields', () => {
       const returnIsInvalid = sinon.stub().returns(errorMessage);
 
       it('returns valid if all fields pass validation', () => {
-
         const validField1 = new FieldDesriptor('name')
           .validate(returnIsValid);
         const validField2 = new FieldDesriptor('name')

--- a/test/services/sessions.test.js
+++ b/test/services/sessions.test.js
@@ -1,7 +1,12 @@
 const sessions = require('../../src/services/sessions');
 const proxyquire = require('proxyquire');
 const { expect, sinon } = require('../util/chai');
-const { testApp, supertest,shouldSetCookie,shouldNotSetCookie } = require('../util/supertest');
+const {
+  testApp,
+  supertest,
+  shouldSetCookie,
+  shouldNotSetCookie
+} = require('../util/supertest');
 const expressSession = require('express-session');
 const { OK, INTERNAL_SERVER_ERROR } = require('http-status-codes');
 


### PR DESCRIPTION
This PR fixes up linting issues that were introduced by #26, #25 and #23.

These issues were not noticed by the team when they were merged due to codacy deciding not to build the repo once ownership was transferred from me to @jenkins-reform-hmcts. Codacy needs the owner to have commited to the repo.

In [src/util/walkMap.js](https://github.com/hmcts/one-per-page/blob/6f0d5f12e0b1ea40ac1ee281946e3217a8d7a449/src/util/walkMap.js) I have ignored linting rather than fixing the issues. This is because I would rather use an [es6 proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to control access to the content instead of running through every key in the content to build a map of all the content. This is very computationally expensive ( between O(2n^2) and O(n ln(n)) depending on i18Nexts implementation of it's lookup function ) and doesn't allow for fallbacks (which would allow common keys to be held in another i18Next namespace).

In [/test/services/fields.test/js](https://github.com/hmcts/one-per-page/blob/6f0d5f12e0b1ea40ac1ee281946e3217a8d7a449/test/services/fields.test.js) I've ignored the file length issue. This is a clear indication that too much is happening in fields.js and I intend to reorganise all the code in to a more logical structure, in which I will also split fields.js into smaller parts. Rather than mess this PR with that change I've opened #29 to track this issue.