### PR TITLE
Bind functions to the step when exposing them to locals

### DIFF
--- a/examples/test-app/steps/respondent/RespondentName.content.en.json
+++ b/examples/test-app/steps/respondent/RespondentName.content.en.json
@@ -1,3 +1,8 @@
 {
-  "title": "Enter your {{- husbandOrWife }}'s current names"
+  "title": "Enter your {{- husbandOrWife }}'s current names",
+  "cya_question": "Your {{- husbandOrWife }}'s name",
+  "error": {
+    "firstName": "Enter your {{- husbandOrWife }}'s first name",
+    "lastName": "Enter your {{- husbandOrWife }}'s last name"
+  }
 }

--- a/examples/test-app/steps/respondent/RespondentName.step.js
+++ b/examples/test-app/steps/respondent/RespondentName.step.js
@@ -18,11 +18,11 @@ class RespondentName extends Question {
     return form(
       textField.ref(this.journey.RespondentTitle, 'husbandOrWife'),
       textField('firstName').joi(
-        'Enter your {{ husbandOrWifes }} first name',
+        this.content.error.firstName,
         Joi.string().required()
       ),
       textField('lastName').joi(
-        'Enter your {{ husbandOrWifes }} last name',
+        this.content.error.lastName,
         Joi.string().required()
       )
     );

--- a/test/steps/Page.test.js
+++ b/test/steps/Page.test.js
@@ -107,12 +107,13 @@ describe('Page', () => {
           return 'page_views/class_locals';
         }
         get foo() {
+          return this.scopedFoo();
+        }
+        scopedFoo() {
           return 'Foo';
         }
-        get bar() {
-          return 'Bar';
-        }
       }();
+      page.bar = 'Bar';
 
       return testStep(page)
         .get()


### PR DESCRIPTION
This PR fixes a bug found in the step function locals where we don't properly bind the function to the step. The result is that `this` refers to the locals object and not the step, which causes problems if you refer to this in a function. 

This bug doesn't appear in getters, only functions.

_example:_
```
class MyStep extends Question {
  fullUrl() {
    return `${ this.journey.baseUrl }/${ this.url }`;
  }
}
```
When called in the template, `this` wouldn't have `journey` defined on it due to `this` being the locals object we build to pass to express for rendering.