### PR TITLE
Demonstrate using globals in templating

### DIFF
--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -26,6 +26,12 @@ lookAndFeel.configure(app, {
       path.resolve(__dirname, 'assets/js/main.js'),
       path.resolve(__dirname, 'assets/scss/main.scss')
     ]
+  },
+  nunjucks: {
+    globals: {
+      phase: 'ALPHA',
+      feedbackLink: 'https://github.com/hmcts/one-per-page/issues/new'
+    }
   }
 });
 

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -20,7 +20,12 @@ const baseUrl = `http://localhost:${config.port}`;
 
 lookAndFeel.configure(app, {
   baseUrl,
-  express: { views: [path.resolve(__dirname, 'steps')] },
+  express: {
+    views: [
+      path.resolve(__dirname, 'steps'),
+      path.resolve(__dirname, 'views')
+    ]
+  },
   webpack: {
     entry: [
       path.resolve(__dirname, 'assets/js/main.js'),

--- a/examples/test-app/steps/CheckYourAnswers.content.en.json
+++ b/examples/test-app/steps/CheckYourAnswers.content.en.json
@@ -1,0 +1,3 @@
+{
+  "title": "Check your answers"
+}

--- a/examples/test-app/steps/CheckYourAnswers.template.html
+++ b/examples/test-app/steps/CheckYourAnswers.template.html
@@ -3,6 +3,3 @@
 {% block head -%}
 <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
 {% endblock %}
-
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}

--- a/examples/test-app/steps/CheckYourAnswers.template.html
+++ b/examples/test-app/steps/CheckYourAnswers.template.html
@@ -1,5 +1,6 @@
+{% extends "question-globals.njk" %}
 {% extends "look-and-feel/layouts/check_your_answers.html" %}
 
-{% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-{% endblock %}
+{% set title %}
+  {{ content.title }}
+{% endset %}

--- a/examples/test-app/steps/Contact.template.html
+++ b/examples/test-app/steps/Contact.template.html
@@ -6,8 +6,6 @@
 <script type="text/javascript" src="{{ asset_path }}main.js"></script>
 {% endblock %}
 
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
 {% set title %}
   {{ content.title }}
 {% endset %}

--- a/examples/test-app/steps/Contact.template.html
+++ b/examples/test-app/steps/Contact.template.html
@@ -1,10 +1,6 @@
+{% extends "question-globals.njk" %}
 {% extends "look-and-feel/layouts/question.html" %}
 {% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
-
-{% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-<script type="text/javascript" src="{{ asset_path }}main.js"></script>
-{% endblock %}
 
 {% set title %}
   {{ content.title }}
@@ -35,5 +31,3 @@
   {% endcall %}
 
 {% endblock %}
-
-

--- a/examples/test-app/steps/Country.content.json
+++ b/examples/test-app/steps/Country.content.json
@@ -10,8 +10,7 @@
         "northernIreland": "Northern Ireland",
         "scotland": "Scotland",
         "england": "England",
-        "wales": "Wales",
-        "hint": "Some advice about the question"
+        "wales": "Wales"
       }
     }
 

--- a/examples/test-app/steps/Country.template.html
+++ b/examples/test-app/steps/Country.template.html
@@ -5,8 +5,6 @@
 <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
 {% endblock %}
 
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
 {% set title %}
   {{ content.title | safe }}
 {% endset %}
@@ -15,7 +13,6 @@
 
   {% call formSection() %}
     {{ selectionButtons(fields.country, content.fields.country.title,
-      hint = content.fields.country.hint,
       options = [
         { label: content.fields.country.northernIreland, value: "northern-ireland" },
         { label: content.fields.country.scotland, value: "scotland" },

--- a/examples/test-app/steps/Country.template.html
+++ b/examples/test-app/steps/Country.template.html
@@ -1,9 +1,7 @@
+{% extends "question-globals.njk" %}
 {% extends "look-and-feel/layouts/question.html" %}
-{% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
 
-{% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-{% endblock %}
+{% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
 
 {% set title %}
   {{ content.title | safe }}

--- a/examples/test-app/steps/Name.template.html
+++ b/examples/test-app/steps/Name.template.html
@@ -1,3 +1,4 @@
+{% extends "question-globals.njk" %}
 {% extends "look-and-feel/layouts/question.html" %}
 {% from "look-and-feel/components/header.njk" import header %}
 {% from "look-and-feel/components/fields.njk" import textbox, formSection %}
@@ -5,10 +6,6 @@
 {% set title %}
   {{ content.title | safe }}
 {% endset %}
-
-{% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-{% endblock %}
 
 {% block fields %}
 

--- a/examples/test-app/steps/Name.template.html
+++ b/examples/test-app/steps/Name.template.html
@@ -2,8 +2,6 @@
 {% from "look-and-feel/components/header.njk" import header %}
 {% from "look-and-feel/components/fields.njk" import textbox, formSection %}
 
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
 {% set title %}
   {{ content.title | safe }}
 {% endset %}

--- a/examples/test-app/steps/Start.template.html
+++ b/examples/test-app/steps/Start.template.html
@@ -1,8 +1,6 @@
 {% extends "look-and-feel/layouts/start_page.html" %}
 
 {% set title='Apply for Divorce' %}
-{% set phase='ALPHA' %}
-{% set feedbackLink='https://github.com/hmcts/look-and-feel/issues/new' %}
 
 {% block head -%}
   <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />

--- a/examples/test-app/steps/respondent/RespondentTitle.template.html
+++ b/examples/test-app/steps/respondent/RespondentTitle.template.html
@@ -1,9 +1,6 @@
+{% extends "question-globals.njk" %}
 {% extends "look-and-feel/layouts/question.html" %}
 {% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
-
-{% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-{% endblock %}
 
 {% set title %}
 Who are you divorcing?

--- a/examples/test-app/steps/respondent/RespondentTitle.template.html
+++ b/examples/test-app/steps/respondent/RespondentTitle.template.html
@@ -5,8 +5,6 @@
 <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
 {% endblock %}
 
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
 {% set title %}
 Who are you divorcing?
 {% endset %}

--- a/examples/test-app/views/question-globals.njk
+++ b/examples/test-app/views/question-globals.njk
@@ -1,0 +1,13 @@
+{% block proposition_header %}
+  {% from "look-and-feel/components/nav.njk" import propositionalNavigation %}
+  {{ propositionalNavigation('Apply for Divorce') }}
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block head -%}
+<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
+<script type="text/javascript" src="{{ asset_path }}main.js"></script>
+{% endblock %}


### PR DESCRIPTION
This PR demonstrates how globals and multiple extends can be used to clean up templates.

**Globals**

Any variables defined in `nunjucks.globals` are available in all templates. This is useful for things that appear on all templates like the phase, service name or the feedback link.

```
lookAndFeel.configure(app, {
  ...
  nunjucks: {
    globals: {
      phase: 'ALPHA',
      feedbackLink: 'https://github.com/hmcts/one-per-page/issues/new'
    }
  }
  ...
});
```

**Multiple extends**

You can extend more than one template in your templates. The last extend will provide the document root. 

This means that you need to put the layout you want to extend last and any extends before this can only set variables and implement blocks. 

The blocks in those earlier extends will override the default blocks set in the layout. You can still of course redeclare these blocks in your template itself.

In the example app we use this to set some blocks that we extend in all templates, the service name in the header and linking the css and js:

*question-globals.njk*:
```
{% block proposition_header %}
  {% from "look-and-feel/components/nav.njk" import propositionalNavigation %}
  {{ propositionalNavigation('Apply for Divorce') }}
{% endblock %}

{% block header_class %}
  with-proposition
{% endblock %}

{% block head -%}
<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
<script type="text/javascript" src="{{ asset_path }}main.js"></script>
{% endblock %}
```

*name.template.html*
```
extends "question-globals.njk"
extends "look-and-feel/layouts/question.html"

{% block fields %}
  ...
{% endblock %}
```