### PR TITLE
Action flow control

### DIFF
--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -2,6 +2,7 @@ const config = require('config');
 const express = require('express');
 const bodyParser = require('body-parser');
 const path = require('path');
+const { BAD_REQUEST } = require('http-status-codes');
 const { journey } = require('@hmcts/one-per-page');
 const lookAndFeel = require('@hmcts/look-and-feel');
 const Sessions = require('./steps/admin/Session.step');
@@ -65,8 +66,19 @@ journey(app, {
 });
 
 app.post('/api/submit', bodyParser.json(), (req, res) => {
-  const response = { status: 'ok', originalBody: req.body };
-  res.json(response);
+  const petitionerLastName = req.body.petitioner.lastName.toLowerCase();
+  const respondentLastName = req.body.respondent.lastName.toLowerCase();
+
+  if (petitionerLastName === respondentLastName) {
+    res.json({ status: 'ok', originalBody: req.body });
+  } else {
+    res.status(BAD_REQUEST);
+    res.json({
+      status: 'bad',
+      originalBody: req.body,
+      error: 'For the purpose of this demo, the last names must match'
+    });
+  }
 });
 
 app.listen(config.port);

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -1,5 +1,6 @@
 const config = require('config');
 const express = require('express');
+const bodyParser = require('body-parser');
 const path = require('path');
 const { journey } = require('@hmcts/one-per-page');
 const lookAndFeel = require('@hmcts/look-and-feel');
@@ -12,7 +13,8 @@ const Contact = require('./steps/Contact.step');
 const Entry = require('./steps/Entry.step');
 const RespondentTitle = require('./steps/respondent/RespondentTitle.step');
 const ExitNorthernIreland = require('./steps/exits/ExitNorthernIreland.step');
-const Exit = require('./steps/exits/Done.step');
+const Done = require('./steps/exits/Done.step');
+const Error = require('./steps/exits/Error.step');
 
 const app = express();
 
@@ -52,12 +54,19 @@ journey(app, {
     Contact,
     CheckYourAnswers,
     ExitNorthernIreland,
-    Exit
+    Done,
+    Error
   ],
   session: {
     redis: { url: config.redisUrl },
     cookie: { secure: false }
-  }
+  },
+  apiUrl: `${baseUrl}/api/submit`
+});
+
+app.post('/api/submit', bodyParser.json(), (req, res) => {
+  const response = { status: 'ok', originalBody: req.body };
+  res.json(response);
 });
 
 app.listen(config.port);

--- a/examples/test-app/package.json
+++ b/examples/test-app/package.json
@@ -15,7 +15,9 @@
     "@hmcts/one-per-page": "./../../",
     "express": "^4.15.3",
     "i18next": "^9.0.0",
-    "joi": "^10.6.0"
+    "joi": "^10.6.0",
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5"
   },
   "devDependencies": {
     "node-dev": "^3.1.3"

--- a/examples/test-app/steps/CheckYourAnswers.step.js
+++ b/examples/test-app/steps/CheckYourAnswers.step.js
@@ -2,13 +2,32 @@ const {
   CheckYourAnswers: CYA,
   section
 } = require('@hmcts/one-per-page/checkYourAnswers');
+const { goTo, action } = require('@hmcts/one-per-page/flow');
+const request = require('request-promise-native');
 
 class CheckYourAnswers extends CYA {
+  constructor(...args) {
+    super(...args);
+    this.sendToAPI = this.sendToAPI.bind(this);
+  }
+
   sections() {
     return [
       section('personal-details', { title: 'Personal Details' }),
       section('respondent-details', { title: 'Respondent Details' })
     ];
+  }
+
+  sendToAPI() {
+    const apiUrl = this.journey.settings.apiUrl;
+    const json = this.journey.values;
+    return request.post(apiUrl, { json });
+  }
+
+  next() {
+    return action(this.sendToAPI)
+      .then(goTo(this.journey.steps.Done))
+      .onFailure(goTo(this.journey.steps.Error));
   }
 }
 

--- a/examples/test-app/steps/Country.step.js
+++ b/examples/test-app/steps/Country.step.js
@@ -49,6 +49,10 @@ class Country extends Question {
       answer: titleise(this.fields.country.value)
     });
   }
+
+  values() {
+    return { petitioner: { country: this.fields.country.value } };
+  }
 }
 
 module.exports = Country;

--- a/examples/test-app/steps/Name.step.js
+++ b/examples/test-app/steps/Name.step.js
@@ -55,6 +55,19 @@ class Name extends Question {
     ];
   }
 
+  values() {
+    return {
+      petitioner: {
+        firstName: this.fields.firstName.value,
+        lastName: this.fields.lastName.value
+      },
+      respondent: {
+        firstName: this.fields.respondentFirstName.value,
+        lastName: this.fields.respondentLastName.value
+      }
+    };
+  }
+
   next() {
     return goTo(this.journey.steps.Contact);
   }

--- a/examples/test-app/steps/exits/Done.content.json
+++ b/examples/test-app/steps/exits/Done.content.json
@@ -1,6 +1,6 @@
 {
   "en": {
-    "title": "BETA",
+    "title": "ALPHA",
     "subTitle": "This is a new service – your <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"/feedback\">feedback</a> will help us improve it",
     "applicationComplete": "Application complete",
     "yourRefNumber": "Your reference number is ",

--- a/examples/test-app/steps/exits/Done.template.html
+++ b/examples/test-app/steps/exits/Done.template.html
@@ -8,7 +8,7 @@
 {% block content %}
 
 <main id="content" role="main">
-	<div class="phase-banner-beta">
+	<div class="phase-banner-alpha">
     <p>
       <strong class="phase-tag">{{ content.title }}</strong>
       <span>{{ content.subTitle | safe }}</span>
@@ -28,12 +28,6 @@
         </p>
 
 			</div>
-
-      <br>
-
-      <p class="text">
-        {{ content.emailSentTo }} <strong class="bold-small"></strong>.
-      </p>
 
       <h2 class="heading-medium">{{content.whatHappensNext}}</h2>
 

--- a/examples/test-app/steps/exits/Error.content.en.json
+++ b/examples/test-app/steps/exits/Error.content.en.json
@@ -1,0 +1,5 @@
+{
+  "title": "Something went wrong",
+  "somethingWentWrong": "Something failed while we were processing your application."
+}
+

--- a/examples/test-app/steps/exits/Error.step.js
+++ b/examples/test-app/steps/exits/Error.step.js
@@ -1,0 +1,5 @@
+const { Page } = require('@hmcts/one-per-page');
+
+class Error extends Page {}
+
+module.exports = Error;

--- a/examples/test-app/steps/exits/Error.step.js
+++ b/examples/test-app/steps/exits/Error.step.js
@@ -1,5 +1,5 @@
-const { Page } = require('@hmcts/one-per-page');
+const { ExitPoint } = require('@hmcts/one-per-page');
 
-class Error extends Page {}
+class Error extends ExitPoint {}
 
 module.exports = Error;

--- a/examples/test-app/steps/exits/Error.template.html
+++ b/examples/test-app/steps/exits/Error.template.html
@@ -1,5 +1,6 @@
 {% extends "look-and-feel/layouts/two_thirds.html" %}
 {% from "look-and-feel/components/header.njk" import header %}
+{% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 
 {% block head -%}
 <link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
@@ -16,4 +17,9 @@
 
 {{ header(content.title) }}
 
+<p>{{ content.somethingWentWrong }}</p>
+
+<a class="button" href="/" role="button">Start again</a>
+
 {% endblock %}
+

--- a/examples/test-app/yarn.lock
+++ b/examples/test-app/yarn.lock
@@ -38,6 +38,7 @@
     callsites "^2.0.0"
     config "^1.26.2"
     connect-redis "^3.3.0"
+    deepmerge "^2.0.1"
     express "^4.15.3"
     express-nunjucks "^2.2.3"
     express-session "^1.15.4"
@@ -1427,7 +1428,7 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
-deepmerge@^2.0.0:
+deepmerge@^2.0.0, deepmerge@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 

--- a/examples/test-app/yarn.lock
+++ b/examples/test-app/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@hmcts/look-and-feel@./../../../look-and-feel":
-  version "1.3.0"
+  version "1.4.0"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
@@ -2765,7 +2765,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3916,7 +3916,21 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2:
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
+request@2, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -4271,6 +4285,10 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -4443,7 +4461,7 @@ topo@3.x.x:
   dependencies:
     hoek "5.x.x"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:

--- a/flow.js
+++ b/flow.js
@@ -1,0 +1,3 @@
+const flow = require('./src/flow');
+
+module.exports = flow;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "callsites": "^2.0.0",
     "config": "^1.26.2",
     "connect-redis": "^3.3.0",
+    "deepmerge": "^2.0.1",
     "express": "^4.15.3",
     "express-nunjucks": "^2.2.3",
     "express-session": "^1.15.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url-parse": "^1.1.9"
   },
   "devDependencies": {
-    "@hmcts/eslint-config": "^1.0.5",
+    "@hmcts/eslint-config": "^1.3.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "chai-jq": "^0.0.9",

--- a/src/flow/RequestBoundJourney.js
+++ b/src/flow/RequestBoundJourney.js
@@ -34,6 +34,12 @@ class RequestBoundJourney {
     throw new Error(`${name} not registered`);
   }
 
+  collectSteps(req, res, next) {
+    this.visitedSteps = this.walkTree();
+    this.visitedSteps.forEach(step => req.currentStep.waitFor(step.ready()));
+    next();
+  }
+
   get entryPoint() {
     if (defined(this.req.session.entryPoint)) {
       return this.req.session.entryPoint;

--- a/src/flow/RequestBoundJourney.js
+++ b/src/flow/RequestBoundJourney.js
@@ -1,4 +1,5 @@
 const { defined } = require('../util/checks');
+const deepmerge = require('deepmerge');
 
 const getName = stepOrName => {
   if (typeof stepOrName === 'string') {
@@ -9,6 +10,8 @@ const getName = stepOrName => {
   }
   throw new Error(`${stepOrName} is not a step`);
 };
+
+const hasValues = step => Object.getOwnPropertyNames(step).includes('values');
 
 class RequestBoundJourney {
   constructor(req, res, steps, settings) {
@@ -49,6 +52,13 @@ class RequestBoundJourney {
 
   walkTree(from = this.entryPoint) {
     return this.instance(from).flowControl.walk();
+  }
+
+  get values() {
+    return this.visitedSteps
+      .filter(hasValues)
+      .map(step => step.values())
+      .reduce((accum, value) => deepmerge(accum, value), {});
   }
 }
 

--- a/src/flow/RequestBoundJourney.js
+++ b/src/flow/RequestBoundJourney.js
@@ -18,6 +18,8 @@ class RequestBoundJourney {
     this.steps = steps;
     this.settings = settings;
     this.instances = {};
+
+    this.collectSteps = this.collectSteps.bind(this);
   }
 
   instance(Step) {

--- a/src/flow/action.js
+++ b/src/flow/action.js
@@ -1,0 +1,50 @@
+const { notDefined } = require('../util/checks');
+const logging = require('@log4js-node/log4js-api');
+
+class Action {
+  constructor(action, nextFlow, errorFlow) {
+    this.action = action;
+    this.nextFlow = nextFlow;
+    this.errorFlow = errorFlow;
+  }
+
+  redirect(req, res) {
+    const promise = this.performAction(req, res);
+
+    return promise
+      .then(() => {
+        if (notDefined(this.nextFlow)) {
+          logging.getLogger(this.name).error('No flow chained to action');
+          return;
+        }
+        this.nextFlow.redirect(req, res);
+      })
+      .catch(() => {
+        if (notDefined(this.errorFlow)) {
+          logging.getLogger(this.name).error('No error flow chained to action');
+          return;
+        }
+        this.errorFlow.redirect(req, res);
+      });
+  }
+
+  performAction(req, res) {
+    try {
+      return Promise.resolve(this.action(req, res));
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  then(nextFlow) {
+    this.nextFlow = nextFlow;
+    return this;
+  }
+
+  onFailure(errorFlow) {
+    this.errorFlow = errorFlow;
+    return this;
+  }
+}
+
+module.exports = Action;

--- a/src/flow/action.js
+++ b/src/flow/action.js
@@ -45,6 +45,10 @@ class Action {
     this.errorFlow = errorFlow;
     return this;
   }
+
+  get step() {
+    return this.nextFlow.step;
+  }
 }
 
 module.exports = Action;

--- a/src/flow/index.js
+++ b/src/flow/index.js
@@ -3,6 +3,7 @@ const Branch = require('./branch');
 const Stop = require('./stop');
 const journey = require('./journey');
 const RequestBoundJourney = require('./RequestBoundJourney');
+const Action = require('./action');
 const {
   ifCompleteThenContinue,
   continueToNext,
@@ -13,11 +14,13 @@ const {
 const goTo = step => new Redirector(step);
 const branch = (...redirectors) => new Branch(...redirectors);
 const stop = step => new Stop(step);
+const action = redirector => new Action(redirector);
 
 module.exports = {
   goTo,
   branch,
   stop,
+  action,
   journey,
   RequestBoundJourney,
   ifCompleteThenContinue,

--- a/src/flow/journey.js
+++ b/src/flow/journey.js
@@ -39,12 +39,12 @@ const options = userOpts => {
   const steps = defaultIfUndefined(userOpts.steps, [])
     .map(constructorFrom);
 
-  return {
+  return Object.assign({}, userOpts, {
     baseUrl: userOpts.baseUrl,
     steps,
     session: sessionProvider,
     noSessionHandler: userOpts.noSessionHandler
-  };
+  });
 };
 
 const journey = (app, userOpts) => {

--- a/src/steps/BaseStep.js
+++ b/src/steps/BaseStep.js
@@ -70,7 +70,7 @@ class BaseStep {
 
     this._router = expressRouter();
     this.middleware.forEach(middleware => {
-      this._router.all(this.path, middleware.bind(this));
+      this._router.all(this.path, middleware);
     });
     this._router.all(this.path, this.handler.bind(this));
     return this._router;

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -48,6 +48,13 @@ class Question extends Page {
     return answer(this);
   }
 
+  values() {
+    return Object.values(this.fields)
+      .reduce((values, field) =>
+        Object.assign(values, { [field.name]: field.value }), {}
+      );
+  }
+
   get form() {
     const logger = logging.getLogger(this.name);
     logger.info('No form defined. Using default empty form.');

--- a/src/steps/check-your-answers/CheckYourAnswers.js
+++ b/src/steps/check-your-answers/CheckYourAnswers.js
@@ -9,6 +9,8 @@ class CheckYourAnswers extends Question {
   constructor(req, res) {
     super(req, res);
     this._sections = [];
+
+    this.collectSteps = this.collectSteps.bind(this);
   }
 
   get middleware() {

--- a/src/steps/index.js
+++ b/src/steps/index.js
@@ -1,0 +1,15 @@
+const BaseStep = require('./BaseStep');
+const Question = require('./Question');
+const EntryPoint = require('./EntryPoint');
+const ExitPoint = require('./ExitPoint');
+const Page = require('./Page');
+const Redirect = require('./Redirect');
+
+module.exports = {
+  BaseStep,
+  Question,
+  EntryPoint,
+  ExitPoint,
+  Page,
+  Redirect
+};

--- a/steps.js
+++ b/steps.js
@@ -1,0 +1,3 @@
+const steps = require('./src/steps');
+
+module.exports = steps;

--- a/test/flow/RequestBoundJourney.test.js
+++ b/test/flow/RequestBoundJourney.test.js
@@ -35,7 +35,7 @@ describe('journey/RequestBoundJourney', () => {
       expect(journey.instance(Step)).an.instanceof(Step);
     });
 
-    it('throws if given a Step that hasn\'t been registered', () => {
+    it("throws if given a Step that hasn't been registered", () => {
       const UnknownStep = class extends BaseStep {
         handler(/* req, res */) { /* intentionally blank */ }
       };
@@ -45,7 +45,7 @@ describe('journey/RequestBoundJourney', () => {
       expect(creatingUnknownStep).to.throw(/UnknownStep not registered/);
     });
 
-    it('throws if given an object that isn\'t a step', () => {
+    it("throws if given an object that isn't a step", () => {
       const journey = new RequestBoundJourney(req, res, steps, settings);
       const arbitraryObj = () => journey.instance({});
 
@@ -177,7 +177,7 @@ describe('journey/RequestBoundJourney', () => {
     });
 
     describe('#values', () => {
-      it('throws if steps haven\'t been collected yet', () => {
+      it("throws if steps haven't been collected yet", () => {
         const _journey = new RequestBoundJourney(req, res, steps, {});
         expect(() => _journey.values).to.throw(
           /Add this.journey.collectSteps to CurrentStep.middleware/
@@ -191,7 +191,7 @@ describe('journey/RequestBoundJourney', () => {
     });
 
     describe('#answers', () => {
-      it('throws if steps haven\'t been collected yet', () => {
+      it("throws if steps haven't been collected yet", () => {
         const _journey = new RequestBoundJourney(req, res, steps, {});
         expect(() => _journey.answers).to.throw(
           /Add this.journey.collectSteps to CurrentStep.middleware/

--- a/test/flow/action.test.js
+++ b/test/flow/action.test.js
@@ -1,0 +1,103 @@
+const Action = require('../../src/flow/action');
+const { expect, sinon } = require('../util/chai');
+const { Defer } = require('../../src/util/promises');
+const logger = require('@log4js-node/log4js-api');
+
+describe('flow/action', () => {
+  const actionStub = sinon.stub();
+  const nextStub = {
+    redirect: sinon.stub(),
+    step: sinon.stub()
+  };
+  const req = {};
+  const res = { send: sinon.stub() };
+
+  beforeEach(() => {
+    sinon.stub(logger, 'getLogger');
+    actionStub.reset();
+    nextStub.redirect.reset();
+    nextStub.step.reset();
+    res.send.reset();
+  });
+
+  afterEach(() => {
+    logger.getLogger.restore();
+  });
+
+  describe('#then', () => {
+    it('sets the actions nextFlow to the given flow', () => {
+      const action = new Action(actionStub);
+      expect(action.nextFlow).undefined;
+
+      action.then(nextStub);
+      expect(action.nextFlow).eql(nextStub);
+    });
+  });
+
+  describe('#onFailure', () => {
+    it('sets the actions errorFlow to the given flow', () => {
+      const action = new Action(actionStub);
+      expect(action.errorFlow).undefined;
+
+      action.onFailure(nextStub);
+      expect(action.errorFlow).eql(nextStub);
+    });
+  });
+
+  describe('#redirect', () => {
+    it('executes the action given to it', () => {
+      const action = new Action(actionStub).then(nextStub);
+      action.redirect(req, res);
+
+      expect(actionStub).calledOnce;
+      expect(actionStub).calledWith(req, res);
+    });
+
+    it('calls the next redirector in it\'s chain', () => {
+      const action = new Action(actionStub).then(nextStub);
+      const promise = action.redirect(req, res);
+      return promise.then(() => expect(nextStub.redirect).calledOnce);
+    });
+
+    it('waits for if the action returns a promise', () => {
+      const defer = new Defer();
+      actionStub.returns(defer);
+
+      const action = new Action(actionStub).then(nextStub);
+      const promise = action.redirect(req, res);
+      expect(nextStub.redirect).not.called;
+
+      defer.resolve();
+      return promise.then(() => expect(nextStub.redirect).calledOnce);
+    });
+
+    it('logs if no nextFlow is given', () => {
+      const errorLogger = sinon.stub();
+      logger.getLogger.returns({ error: errorLogger });
+      return new Action(actionStub)
+        .redirect(req, res)
+        .then(() =>
+          expect(errorLogger).calledWith('No flow chained to action')
+        );
+    });
+
+    it('calls the error redirector if the action throws', () => {
+      const action = new Action(actionStub)
+        .onFailure(nextStub);
+      actionStub.throws(new Error('I failed'));
+
+      return action
+        .redirect(req, res)
+        .then(() => expect(nextStub.redirect).calledOnce);
+    });
+    it('calls the error redirector if the promise fails', () => {
+      const action = new Action(actionStub)
+        .onFailure(nextStub);
+      actionStub.returns(Promise.reject(new Error('I failed')));
+
+      return action
+        .redirect(req, res)
+        .then(() => expect(nextStub.redirect).calledOnce);
+    });
+  });
+});

--- a/test/flow/action.test.js
+++ b/test/flow/action.test.js
@@ -53,7 +53,7 @@ describe('flow/action', () => {
       expect(actionStub).calledWith(req, res);
     });
 
-    it('calls the next redirector in it\'s chain', () => {
+    it("calls the next redirector in it's chain", () => {
       const action = new Action(actionStub).then(nextStub);
       const promise = action.redirect(req, res);
       return promise.then(() => expect(nextStub.redirect).calledOnce);

--- a/test/flow/fixtures/branchingJourney.fixture.js
+++ b/test/flow/fixtures/branchingJourney.fixture.js
@@ -1,0 +1,47 @@
+const EntryPoint = require('../../../src/steps/EntryPoint');
+const Question = require('../../../src/steps/Question');
+const { branch, goTo, RequestBoundJourney } = require('../../../src/flow');
+const CheckYourAnswers = require('../../../src/steps/check-your-answers/CheckYourAnswers'); // eslint-disable-line max-len
+const { textField, form } = require('../../../src/forms');
+
+class Entry extends EntryPoint {
+  next() {
+    return goTo(this.journey.steps.Branch);
+  }
+}
+class Branch extends Question {
+  get form() {
+    return form(textField('branchControl'));
+  }
+  next() {
+    const isA = this.fields.branchControl.value === 'A';
+    const isB = this.fields.branchControl.value === 'B';
+    return branch(
+      goTo(this.journey.steps.A).if(isA),
+      goTo(this.journey.steps.B).if(isB),
+      goTo(this.journey.steps.CheckAnswers)
+    );
+  }
+}
+class B extends Question {
+  next() {
+    return goTo(this.journey.steps.CheckAnswers);
+  }
+}
+class A extends Question {
+  next() {
+    return goTo(this.journey.steps.CheckAnswers);
+  }
+}
+class CheckAnswers extends CheckYourAnswers {}
+const steps = { Entry, A, B, Branch, CheckAnswers };
+const session = {
+  entryPoint: Entry.name,
+  Branch: { branchControl: 'A' }
+};
+const req = { session };
+const res = {};
+
+const journey = new RequestBoundJourney(req, res, steps, {});
+
+module.exports = { journey, Entry, Branch, A, CheckAnswers };

--- a/test/flow/fixtures/completeJourney.fixture.js
+++ b/test/flow/fixtures/completeJourney.fixture.js
@@ -1,0 +1,32 @@
+const EntryPoint = require('../../../src/steps/EntryPoint');
+const Question = require('../../../src/steps/Question');
+const CheckYourAnswers = require('../../../src/steps/check-your-answers/CheckYourAnswers'); // eslint-disable-line max-len
+const { goTo, RequestBoundJourney } = require('../../../src/flow');
+const { textField, form } = require('../../../src/forms');
+
+class Entry extends EntryPoint {
+  next() {
+    return goTo(this.journey.steps.Name);
+  }
+}
+class Name extends Question {
+  get form() {
+    return form(textField('firstName'), textField('lastName'));
+  }
+  next() {
+    return goTo(this.journey.steps.CheckAnswers);
+  }
+}
+class CheckAnswers extends CheckYourAnswers {}
+const steps = { Entry, Name, CheckAnswers };
+const session = {
+  entryPoint: Entry.name,
+  Name: { firstName: 'Michael', lastName: 'Allen' },
+  CheckAnswers: { statementOfTruth: true }
+};
+const res = {};
+const req = { session };
+
+const journey = () => new RequestBoundJourney(req, res, steps, {});
+
+module.exports = { journey, Entry, Name, CheckAnswers };

--- a/test/flow/fixtures/incompleteJourney.fixture.js
+++ b/test/flow/fixtures/incompleteJourney.fixture.js
@@ -1,0 +1,32 @@
+const EntryPoint = require('../../../src/steps/EntryPoint');
+const Question = require('../../../src/steps/Question');
+const { textField, form } = require('../../../src/forms');
+const { goTo, RequestBoundJourney } = require('../../../src/flow');
+const CheckYourAnswers = require('../../../src/steps/check-your-answers/CheckYourAnswers'); // eslint-disable-line max-len
+const Joi = require('joi');
+
+class Entry extends EntryPoint {
+  next() {
+    return goTo(this.journey.steps.Name);
+  }
+}
+class Name extends Question {
+  get form() {
+    return form(textField('notPresent').joi(Joi.string().required()));
+  }
+  next() {
+    return goTo(this.journey.steps.CheckAnswers);
+  }
+}
+class CheckAnswers extends CheckYourAnswers {}
+const steps = { Entry, Name, CheckAnswers };
+const session = {
+  entryPoint: Entry.name,
+  Name: {}
+};
+const req = { session };
+const res = {};
+
+const journey = new RequestBoundJourney(req, res, steps, {});
+
+module.exports = { journey, Entry, Name };

--- a/test/flow/fixtures/longLoopingJourney.fixture.js
+++ b/test/flow/fixtures/longLoopingJourney.fixture.js
@@ -1,0 +1,33 @@
+const EntryPoint = require('../../../src/steps/EntryPoint');
+const Question = require('../../../src/steps/Question');
+const { goTo, RequestBoundJourney } = require('../../../src/flow');
+const CheckYourAnswers = require('../../../src/steps/check-your-answers/CheckYourAnswers'); // eslint-disable-line max-len
+
+class Entry extends EntryPoint {
+  next() {
+    return goTo(this.journey.steps.A);
+  }
+}
+class A extends Question {
+  next() {
+    return goTo(this.journey.steps.B);
+  }
+}
+class B extends Question {
+  next() {
+    return goTo(this.journey.steps.C);
+  }
+}
+class C extends Question {
+  next() {
+    return goTo(this.journey.steps.A);
+  }
+}
+class CheckAnswers extends CheckYourAnswers {}
+const steps = { Entry, A, B, C, CheckAnswers };
+const req = { session: { entryPoint: Entry.name } };
+const res = {};
+
+const journey = new RequestBoundJourney(req, res, steps, {});
+
+module.exports = journey;

--- a/test/flow/fixtures/loopingJourney.fixture.js
+++ b/test/flow/fixtures/loopingJourney.fixture.js
@@ -1,0 +1,28 @@
+const EntryPoint = require('../../../src/steps/EntryPoint');
+const Question = require('../../../src/steps/Question');
+const { goTo, RequestBoundJourney } = require('../../../src/flow');
+const CheckYourAnswers = require('../../../src/steps/check-your-answers/CheckYourAnswers'); // eslint-disable-line max-len
+
+class Entry extends EntryPoint {
+  next() {
+    return goTo(this.journey.steps.A);
+  }
+}
+class A extends Question {
+  next() {
+    return goTo(this.journey.steps.B);
+  }
+}
+class B extends Question {
+  next() {
+    return goTo(this.journey.steps.A);
+  }
+}
+class CheckAnswers extends CheckYourAnswers {}
+const steps = { Entry, A, B, CheckAnswers };
+const req = { session: { entryPoint: Entry.name } };
+const res = {};
+
+const journey = new RequestBoundJourney(req, res, steps, {});
+
+module.exports = journey;

--- a/test/forms/field.test.js
+++ b/test/forms/field.test.js
@@ -29,7 +29,7 @@ describe('forms/field', () => {
         expect(f.serialize()).to.eql({ [f.name]: f.value });
       });
 
-      it('returns it\'s parsers nullValue if no value', () => {
+      it("returns it's parsers nullValue if no value", () => {
         const fakeParser = { nullValue: 'foobar' };
         const f = new FieldDesriptor('name', fakeParser);
         expect(f.serialize()).to.eql({ [f.name]: fakeParser.nullValue });
@@ -139,7 +139,7 @@ describe('forms/field', () => {
     });
 
     describe('#validated', () => {
-      it('returns false when a field hasn\'t been validated yet', () => {
+      it("returns false when a field hasn't been validated yet", () => {
         const nameField = new FieldDesriptor('name');
         expect(nameField.validated).to.be.false;
       });

--- a/test/forms/form.test.js
+++ b/test/forms/form.test.js
@@ -244,7 +244,7 @@ describe('forms/form', () => {
     });
 
     describe('#validated', () => {
-      it('returns false when a form hasn\'t been validated yet', () => {
+      it("returns false when a form hasn't been validated yet", () => {
         const nameField = new FieldDesriptor('name');
         const f = new Form([nameField]);
         expect(f.validated).to.be.false;

--- a/test/forms/formProxyHandler.test.js
+++ b/test/forms/formProxyHandler.test.js
@@ -82,7 +82,7 @@ describe('forms/formProxyHandler', () => {
     it('is enumerable', () => {
       expect(descriptor.enumerable).to.be.true;
     });
-    it('has the field as it\'s value', () => {
+    it("has the field as it's value", () => {
       expect(descriptor.value).to.eql(_form.fields[0]);
     });
   });

--- a/test/forms/ref.test.js
+++ b/test/forms/ref.test.js
@@ -1,3 +1,4 @@
+/* eslint quotes: ["error", "single", { "avoidEscape": true }] */
 const { expect } = require('../util/chai');
 const { FieldDesriptor } = require('../../src/forms/field');
 const { ref, Reference } = require('../../src/forms/ref');
@@ -21,7 +22,7 @@ describe('forms/ref', () => {
 
     ['parse', 'deserialize'].forEach(func => {
       describe(`#${func}`, () => {
-        it('loads from session from it\'s step not the current step', () => {
+        it("loads from session from it's step not the current step", () => {
           const r = new Reference(fakeStep, 'foo', textParser);
           const req = {
             currentStep: { name: 'OtherStep' },

--- a/test/i18n/contentProxy.test.js
+++ b/test/i18n/contentProxy.test.js
@@ -43,7 +43,7 @@ describe('i18n/contentProxy', () => {
         expect(key[Symbol.toStringTag]()).to.eql('Content');
       });
 
-      it('throws if key doesn\'t exist', () => {
+      it("throws if key doesn't exist", () => {
         exists.withArgs('FakeStep:key').returns(false);
         const key = proxy.key;
         expect(() => key.toString())

--- a/test/middleware/errorIfNotReady.test.js
+++ b/test/middleware/errorIfNotReady.test.js
@@ -8,7 +8,7 @@ describe('middleware/errorIfNotReady', () => {
       return 'ReadyStep';
     },
     ready() {
-      return Promise.resolve('I\'m ready');
+      return Promise.resolve("I'm ready");
     }
   };
   const notReadyStep = {

--- a/test/steps/BaseStep.test.js
+++ b/test/steps/BaseStep.test.js
@@ -108,24 +108,6 @@ describe('steps/BaseStep', () => {
       return testStep(step).get()
         .expect(OK, { foo: 'Foo' });
     });
-
-    it('are bound to the current step', () => {
-      const step = class extends BaseStep {
-        scopedMiddleware(req, res, next) {
-          req.stepUrl = this.path;
-          next();
-        }
-        get middleware() {
-          return [this.scopedMiddleware];
-        }
-        handler(req, res) {
-          res.status(OK).json({ path: req.stepUrl });
-        }
-      };
-
-      return testStep(step).get()
-        .expect(OK, { path: '/step' });
-    });
   });
 
   describe('#dirname', () => {

--- a/test/steps/EntryPoint.test.js
+++ b/test/steps/EntryPoint.test.js
@@ -34,7 +34,7 @@ describe('steps/EntryPoint', () => {
         });
     });
 
-    it('stores it\'s name as the entryPoint in the session', () => {
+    it("stores it's name as the entryPoint in the session", () => {
       return testStep(redirect)
         .get()
         .session(session => {

--- a/test/steps/Question.test.js
+++ b/test/steps/Question.test.js
@@ -131,6 +131,32 @@ describe('steps/Question', () => {
       });
     });
 
+    describe('#values', () => {
+      it('returns all of form field values', () => {
+        const NameStep = class extends SimpleQuestion {
+          static get path() {
+            return '/next-step';
+          }
+          get form() {
+            return form(
+              field('name')
+            );
+          }
+        };
+        const req = {
+          journey: {},
+          session: { NameStep: { name: 'John' } }
+        };
+        const res = {};
+        const step = new NameStep(req, res);
+        step.retrieve().validate();
+
+        const _values = step.values();
+        expect(_values).to.be.an('object');
+        expect(_values).to.have.property('name', 'John');
+      });
+    });
+
     describe('#answers', () => {
       it('returns a default answer', () => {
         const NameStep = class extends SimpleQuestion {

--- a/test/steps/check-your-answers/section.test.js
+++ b/test/steps/check-your-answers/section.test.js
@@ -48,7 +48,7 @@ describe('steps/check-your-answers/section', () => {
   describe('#incomplete', () => {
     const s = section('foo');
 
-    it('returns true if any answers aren\'t complete', () => {
+    it("returns true if any answers aren't complete", () => {
       s.answers = [incompleteAnswer];
       expect(s.incomplete).to.be.true;
     });
@@ -72,7 +72,7 @@ describe('steps/check-your-answers/section', () => {
       expect(s.atLeast1Completed).to.be.true;
     });
 
-    it('returns false if all answers aren\'t complete', () => {
+    it("returns false if all answers aren't complete", () => {
       s.answers = [incompleteAnswer];
       expect(s.atLeast1Completed).to.be.false;
     });

--- a/test/util/fs.test.js
+++ b/test/util/fs.test.js
@@ -59,7 +59,7 @@ describe('util/fs', () => {
       return expect(readJson(fixturesDir)).rejectedWith(/illegal operation/);
     });
 
-    it('rejects if a file doesn\'t exist', () => {
+    it("rejects if a file doesn't exist", () => {
       return expect(readJson('/non-existent')).rejectedWith(/no such file/);
     });
   });
@@ -76,7 +76,7 @@ describe('util/fs', () => {
       return expect(readFile(fixturesDir)).rejectedWith(/illegal operation/);
     });
 
-    it('rejects if a file doesn\'t exist', () => {
+    it("rejects if a file doesn't exist", () => {
       return expect(readFile('/non-existent')).rejectedWith(/no such file/);
     });
   });

--- a/test/util/promises.test.js
+++ b/test/util/promises.test.js
@@ -90,7 +90,7 @@ describe('util/promises', () => {
   });
 
   describe('#timeout', () => {
-    it('rejects if the given promise doesn\'t resolve in time', () => {
+    it("rejects if the given promise doesn't resolve in time", () => {
       const result = timeout(10, new Promise(() => {
         /* intentionally blank */
       }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"


### PR DESCRIPTION
This PR introduces the `action` flow control, which will execute the function it's given when before routing the user to the next step.

**action flow control**

The action flow control executes some function before issuing the redirect to the user.

The benefits of this is that you don't need a discrete step just to perform an action, you could perform a number of things before finally issuing a redirect and you the user doesn't have to make an explicit server round trip for the action itself.

One down side is that we need to explicitly bind the function you want to use in the action if you are passing a function that exists on an object. This is a well known limitation with ES6 classes (that class methods aren't bound to the class) and can't be avoided without significant performance hits.

```
class CheckYourAnswers extends CYA {
  constructor(...args) {
    super(...args);
    this.sendToAPI = this.sendToAPI.bind(this);
  }

  sendToAPI() {
    const apiUrl = this.journey.settings.apiUrl;
    const json = this.journey.values;
    return request.post(apiUrl, { json });
  }

  next() {
    return action(this.sendToAPI)
      .then(goTo(this.journey.steps.Done))
      .onFailure(goTo(this.journey.steps.Error));
  }
}
```

**Question #values**

Questions now declare a `values` function that by default outputs the values of all non-reference fields in it's form. 

The Journey object that is attached to `[step].journey` also provides a `values` function that will run through the flow tree and collect all the steps values, combining them in to a single object.