### PR TITLE
Compound field

### DIFF
--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -16,6 +16,8 @@ const RespondentTitle = require('./steps/respondent/RespondentTitle.step');
 const ExitNorthernIreland = require('./steps/exits/ExitNorthernIreland.step');
 const Done = require('./steps/exits/Done.step');
 const Error = require('./steps/exits/Error.step');
+const ExitDate = require('./steps/exits/ExitDate.step');
+const DateOfMarriage = require('./steps/DateOfMarriage.step');
 
 const app = express();
 
@@ -56,7 +58,9 @@ journey(app, {
     CheckYourAnswers,
     ExitNorthernIreland,
     Done,
-    Error
+    Error,
+    ExitDate,
+    DateOfMarriage
   ],
   session: {
     redis: { url: config.redisUrl },

--- a/examples/test-app/package.json
+++ b/examples/test-app/package.json
@@ -16,6 +16,7 @@
     "express": "^4.15.3",
     "i18next": "^9.0.0",
     "joi": "^10.6.0",
+    "moment": "^2.19.3",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5"
   },

--- a/examples/test-app/steps/DateOfMarriage.content.en.json
+++ b/examples/test-app/steps/DateOfMarriage.content.en.json
@@ -1,0 +1,14 @@
+{
+  "title": "When did you get married?",
+  "date": {
+    "question": "Date you got married",
+    "hint": "For example, {{ today }}",
+    "dayLabel": "Day",
+    "monthLabel": "Month",
+    "yearLabel": "Year",
+    "allRequired": "Enter the date you got married",
+    "dayRequired": "Enter the day you got married",
+    "monthRequired": "Enter the month you got married",
+    "yearRequired": "Enter the year you got married"
+  }
+}

--- a/examples/test-app/steps/DateOfMarriage.step.js
+++ b/examples/test-app/steps/DateOfMarriage.step.js
@@ -1,0 +1,50 @@
+const { Question } = require('@hmcts/one-per-page/steps');
+const { form, dateField } = require('@hmcts/one-per-page/forms');
+const { branch, goTo } = require('@hmcts/one-per-page/flow');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
+const moment = require('moment');
+
+class DateOfMarriage extends Question {
+  get form() {
+    return form(
+      dateField(
+        'date',
+        {
+          allRequired: this.content.date.allRequired,
+          dayRequired: this.content.date.dayRequired,
+          monthRequired: this.content.date.monthRequired,
+          yearRequired: this.content.date.yearRequired
+        }
+      ).mapValue(
+        ({ day, month, year }) => moment({ day, month, year })
+      )
+    );
+  }
+
+  get today() {
+    return moment().format('D M YYYY');
+  }
+
+  next() {
+    const oneYearAgo = moment().subtract(1, 'year');
+    const marriedLessThan1Year = this.fields.date.value.isAfter(oneYearAgo);
+
+    return branch(
+      goTo(this.journey.steps.ExitDate).if(marriedLessThan1Year),
+      goTo(this.journey.steps.Country)
+    );
+  }
+
+  answers() {
+    return answer(this, {
+      question: this.content.date.question,
+      answer: this.fields.date.value.format('DD/MM/YYYY')
+    });
+  }
+
+  values() {
+    return { marriage: { date: this.fields.date.value.format('YYYY-MM-DD') } };
+  }
+}
+
+module.exports = DateOfMarriage;

--- a/examples/test-app/steps/DateOfMarriage.template.html
+++ b/examples/test-app/steps/DateOfMarriage.template.html
@@ -1,0 +1,26 @@
+{% extends "question-globals.njk" %}
+{% extends "look-and-feel/layouts/question.html" %}
+
+{% from "look-and-feel/components/fields.njk" import formSection, date %}
+
+{% set title %}
+{{ content.title }}
+{% endset %}
+
+{% block fields %}
+
+  {% call formSection() %}
+
+    {{ date(fields.date, content.date.question,
+      hideQuestion = true,
+      hint = content.date.hint,
+      labels = {
+        day: content.date.dayLabel,
+        month: content.date.monthLabel,
+        year: content.date.yearLabel
+      }
+    ) }}
+
+  {% endcall %}
+
+{% endblock %}

--- a/examples/test-app/steps/Entry.step.js
+++ b/examples/test-app/steps/Entry.step.js
@@ -6,7 +6,7 @@ class Entry extends EntryPoint {
   }
 
   next() {
-    return goTo(this.journey.steps.Country);
+    return goTo(this.journey.steps.DateOfMarriage);
   }
 }
 

--- a/examples/test-app/steps/exits/ExitDate.content.json
+++ b/examples/test-app/steps/exits/ExitDate.content.json
@@ -1,0 +1,8 @@
+{
+  "en": {
+    "title": "You haven't been married for long enough to get a divorce",
+    "englandAndWalesRule": "In England and Wales you can only divorce after at least 1 year of marriage.",
+    "suggestLegalSeparation": "You can <a href='https://www.gov.uk/legal-separation'>apply for a legal separation</a> if you've been married for less than a year.",
+    "suggestAnnul": "You may also be able to <a href='https://www.gov.uk/how-to-annul-marriage'>annul your marriage</a>."
+  }
+}

--- a/examples/test-app/steps/exits/ExitDate.step.js
+++ b/examples/test-app/steps/exits/ExitDate.step.js
@@ -1,0 +1,5 @@
+const { ExitPoint } = require('@hmcts/one-per-page/steps');
+
+class ExitDate extends ExitPoint {}
+
+module.exports = ExitDate;

--- a/examples/test-app/steps/exits/ExitDate.template.html
+++ b/examples/test-app/steps/exits/ExitDate.template.html
@@ -1,0 +1,21 @@
+{% extends "look-and-feel/layouts/two_thirds.html" %}
+{% from "look-and-feel/components/header.njk" import header %}
+{% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
+
+{% block head -%}
+<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
+{% endblock %}
+
+{% block breadcrumbs %}
+{{ phaseBanner(phase, feedbackLink) }}
+{% endblock %}
+
+{% block two_thirds %}
+
+{{ header(content.title) }}
+
+<p>{{ content.englandAndWalesRule }}</p>
+<p>{{ content.suggestLegalSeparation | safe }}</p>
+<p>{{ content.suggestAnnul | safe }}</p>
+
+{% endblock %}

--- a/examples/test-app/yarn.lock
+++ b/examples/test-app/yarn.lock
@@ -31,7 +31,7 @@
     webpack-dev-middleware "^1.12.0"
 
 "@hmcts/one-per-page@./../../":
-  version "2.0.0-2"
+  version "2.0.0-3"
   dependencies:
     "@log4js-node/log4js-api" "^1.0.0"
     body-parser "^1.17.2"
@@ -2954,6 +2954,10 @@ mixin-object@^2.0.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@^2.19.3:
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
 
 ms@2.0.0:
   version "2.0.0"

--- a/src/forms/complex/dateField.js
+++ b/src/forms/complex/dateField.js
@@ -1,0 +1,46 @@
+const Joi = require('joi');
+const { compoundField, errorFor } = require('../compoundField');
+const { textField } = require('../simpleFields');
+
+const dateField = (
+  name,
+  {
+    allRequired = 'Enter a date',
+    dayRequired = 'Enter a day',
+    monthRequired = 'Enter a month',
+    yearRequired = 'Enter a year'
+  } = {}
+) => {
+  const dayField = textField('day');
+  const monthField = textField('month');
+  const yearField = textField('year');
+  return compoundField(name, dayField, monthField, yearField)
+    .joi(
+      errorFor('day', dayRequired),
+      Joi.object()
+        .with('year', 'day')
+        .with('month', 'day')
+    )
+    .joi(
+      errorFor('month', monthRequired),
+      Joi.object()
+        .with('year', 'month')
+        .with('day', 'month')
+    )
+    .joi(
+      errorFor('year', yearRequired),
+      Joi.object()
+        .with('day', 'year')
+        .with('month', 'year')
+    )
+    .joi(
+      allRequired,
+      Joi.object().keys({
+        day: Joi.string().required(),
+        month: Joi.string().required(),
+        year: Joi.string().required()
+      })
+    );
+};
+
+module.exports = dateField;

--- a/src/forms/compoundField.js
+++ b/src/forms/compoundField.js
@@ -3,7 +3,7 @@ const option = require('option');
 const FieldError = require('./fieldError');
 const { hasKeys, isObject, notDefined } = require('../util/checks');
 
-class BadValidationTargetError extends Error {
+class TargetNotFoundError extends Error {
   constructor(id, field) {
     const targets = [field.name, ...field.fields.map(f => f.name)];
     const message = `${id} not recognised. Must be one of ${targets.join(',')}`;
@@ -97,7 +97,7 @@ class CompoundField {
     } else if (this.fields.some(f => f.name === id)) {
       this[id].validations.push(validator);
     } else {
-      throw new BadValidationTargetError(id, this);
+      throw new TargetNotFoundError(id, this);
     }
     return this;
   }

--- a/src/forms/compoundField.js
+++ b/src/forms/compoundField.js
@@ -1,5 +1,6 @@
 const Joi = require('joi');
 const option = require('option');
+const FieldError = require('./fieldError');
 
 class BadValidationTargetError extends Error {
   constructor(id, field) {
@@ -127,6 +128,13 @@ class CompoundField {
     return this.fields
       .map(field => field.serialize())
       .reduce((obj, value) => Object.assign(obj, value), {});
+  }
+
+  get mappedErrors() {
+    return [
+      this.errors.map(error => new FieldError(this, error)),
+      ...this.fields.map(field => field.mappedErrors)
+    ].reduce((left, right) => [...left, ...right], []);
   }
 }
 

--- a/src/forms/compoundField.js
+++ b/src/forms/compoundField.js
@@ -1,20 +1,47 @@
 const Joi = require('joi');
 const option = require('option');
 
+class BadValidationTargetError extends Error {
+  constructor(id, field) {
+    const targets = [field.name, ...field.fields.map(f => f.name)];
+    const message = `${id} not recognised. Must be one of ${targets.join(',')}`;
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+    this.targetId = id;
+  }
+}
+
 const isNullOrUndefined = value =>
   typeof value === 'undefined' || value === null;
 
-const failOnFirstFailure = (field, validations) => {
+const failOnFirstFailure = validations => {
   if (!(validations && validations.length)) {
     return { result: true, errors: [] };
   }
   const [currentValidation, ...rest] = validations;
-  const maybeError = currentValidation(field);
+  const maybeError = currentValidation();
 
-  if (isNullOrUndefined(maybeError)) {
-    return failOnFirstFailure(field, rest);
+  if (!maybeError || isNullOrUndefined(maybeError)) {
+    return failOnFirstFailure(rest);
   }
   return { result: false, errors: [maybeError] };
+};
+
+const parseErrorTarget = (targetOrMessage, fallbackId) => {
+  if (typeof targetOrMessage === 'string') {
+    return { message: targetOrMessage, id: fallbackId };
+  }
+  const isObject = typeof targetOrMessage === 'object';
+  if (isObject && 'message' in targetOrMessage && 'id' in targetOrMessage) {
+    return targetOrMessage;
+  }
+  throw new Error(`Cannot parse ${targetOrMessage}`);
+};
+
+const errorFor = (id, message) => {
+  return { id, message };
 };
 
 class CompoundField {
@@ -24,7 +51,7 @@ class CompoundField {
     this.fields = fields;
     this.validations = [];
     this.errors = [];
-    this._validated = false;
+    this.validated = false;
 
     fields.forEach(field => {
       this[field.name] = field;
@@ -54,23 +81,46 @@ class CompoundField {
   validate() {
     const results = this.fields.map(field => field.validate());
     if (results.some(result => result === false)) {
-      this._validated = true;
-      this._valid = false;
+      this.validated = true;
+      this.valid = false;
       return false;
     }
-    const { result, errors } = failOnFirstFailure(this, this.validations);
+    const { result, errors } = failOnFirstFailure(this.validations);
     this.errors = errors;
-    this._valid = result;
-    this._validated = true;
+    this.valid = result;
+    this.validated = true;
     return result;
   }
 
-  joi(message, joiSchema) {
-    this.validations.push(field => {
-      const { error } = Joi.validate(field.value, joiSchema);
-      return error ? message : error;
-    });
+  addValidation(id, message, validator) {
+    if (id === this.name) {
+      this.validations.push(validator);
+    } else if (this.fields.some(f => f.name === id)) {
+      this[id].validations.push(validator);
+    } else {
+      throw new BadValidationTargetError(id, this);
+    }
     return this;
+  }
+
+  joi(targetOrError, joiSchema) {
+    const { message, id } = parseErrorTarget(targetOrError, this.name);
+    const validator = () => {
+      const { error } = Joi.validate(this.value, joiSchema);
+      return error ? message : error;
+    };
+    return this.addValidation(id, message, validator);
+  }
+
+  check(targetOrError, predicate) {
+    const { message, id } = parseErrorTarget(targetOrError, this.name);
+    const validator = () => {
+      if (predicate(this.value)) {
+        return false;
+      }
+      return message;
+    };
+    return this.addValidation(id, message, validator);
   }
 
   get value() {
@@ -80,4 +130,6 @@ class CompoundField {
   }
 }
 
-module.exports = CompoundField;
+const compoundField = (name, ...fields) => new CompoundField(name, ...fields);
+
+module.exports = { CompoundField, compoundField, errorFor };

--- a/src/forms/compoundField.js
+++ b/src/forms/compoundField.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const option = require('option');
 const FieldError = require('./fieldError');
+const { hasKeys, isObject, notDefined } = require('../util/checks');
 
 class BadValidationTargetError extends Error {
   constructor(id, field) {
@@ -14,9 +15,6 @@ class BadValidationTargetError extends Error {
   }
 }
 
-const isNullOrUndefined = value =>
-  typeof value === 'undefined' || value === null;
-
 const failOnFirstFailure = validations => {
   if (!(validations && validations.length)) {
     return { result: true, errors: [] };
@@ -24,7 +22,7 @@ const failOnFirstFailure = validations => {
   const [currentValidation, ...rest] = validations;
   const maybeError = currentValidation();
 
-  if (!maybeError || isNullOrUndefined(maybeError)) {
+  if (!maybeError || notDefined(maybeError)) {
     return failOnFirstFailure(rest);
   }
   return { result: false, errors: [maybeError] };
@@ -35,8 +33,7 @@ const errorFor = (id, message) => {
 };
 
 const parseErrorTarget = (targetOrMessage, fallbackId) => {
-  const isObject = typeof targetOrMessage === 'object';
-  if (isObject && 'message' in targetOrMessage && 'id' in targetOrMessage) {
+  if (isObject(targetOrMessage) && hasKeys(targetOrMessage, 'message', 'id')) {
     return targetOrMessage;
   }
   return errorFor(fallbackId, targetOrMessage);

--- a/src/forms/compoundField.js
+++ b/src/forms/compoundField.js
@@ -1,0 +1,83 @@
+const Joi = require('joi');
+const option = require('option');
+
+const isNullOrUndefined = value =>
+  typeof value === 'undefined' || value === null;
+
+const failOnFirstFailure = (field, validations) => {
+  if (!(validations && validations.length)) {
+    return { result: true, errors: [] };
+  }
+  const [currentValidation, ...rest] = validations;
+  const maybeError = currentValidation(field);
+
+  if (isNullOrUndefined(maybeError)) {
+    return failOnFirstFailure(field, rest);
+  }
+  return { result: false, errors: [maybeError] };
+};
+
+class CompoundField {
+  constructor(name, ...fields) {
+    this.name = name;
+    this.id = name;
+    this.fields = fields;
+    this.validations = [];
+    this.errors = [];
+    this._validated = false;
+
+    fields.forEach(field => {
+      this[field.name] = field;
+    });
+  }
+
+  parse(body = {}) {
+    this.fields.forEach(field => field.parse(body));
+
+    return this;
+  }
+
+  deserialize(session = {}) {
+    const values = option
+      .fromNullable(session[this.name])
+      .valueOrElse({});
+
+    this.fields.forEach(field => field.deserialize(values));
+
+    return this;
+  }
+
+  serialize() {
+    return { [this.name]: this.value };
+  }
+
+  validate() {
+    const results = this.fields.map(field => field.validate());
+    if (results.some(result => result === false)) {
+      this._validated = true;
+      this._valid = false;
+      return false;
+    }
+    const { result, errors } = failOnFirstFailure(this, this.validations);
+    this.errors = errors;
+    this._valid = result;
+    this._validated = true;
+    return result;
+  }
+
+  joi(message, joiSchema) {
+    this.validations.push(field => {
+      const { error } = Joi.validate(field.value, joiSchema);
+      return error ? message : error;
+    });
+    return this;
+  }
+
+  get value() {
+    return this.fields
+      .map(field => field.serialize())
+      .reduce((obj, value) => Object.assign(obj, value), {});
+  }
+}
+
+module.exports = CompoundField;

--- a/src/forms/field.js
+++ b/src/forms/field.js
@@ -1,6 +1,7 @@
 const option = require('option');
 const Joi = require('joi');
 const { nonEmptyTextParser } = require('./fieldParsers');
+const FieldError = require('./fieldError');
 const { notDefined } = require('../util/checks');
 
 const isNullOrUndefined = value =>
@@ -87,6 +88,10 @@ class FieldDesriptor {
 
   get errors() {
     return this._errors;
+  }
+
+  get mappedErrors() {
+    return this.errors.map(error => new FieldError(this, error));
   }
 
   get valid() {

--- a/src/forms/fieldParsers.js
+++ b/src/forms/fieldParsers.js
@@ -1,7 +1,7 @@
 const textParser = {
   nullValue: undefined, // eslint-disable-line no-undefined
   parse(value) {
-    return value.toString();
+    return value === '' ? this.nullValue : value.toString();
   }
 };
 

--- a/src/forms/form.js
+++ b/src/forms/form.js
@@ -85,10 +85,9 @@ class Form {
   }
 
   get errors() {
-    const fieldErrors = this.fields
+    return this.fields
       .map(field => field.mappedErrors)
       .reduce((accum, errorsArr) => [...accum, ...errorsArr], []);
-    return fieldErrors;
   }
 }
 

--- a/src/forms/form.js
+++ b/src/forms/form.js
@@ -86,10 +86,7 @@ class Form {
 
   get errors() {
     const fieldErrors = this.fields
-      .map(field => {
-        const errors = field.errors.map(error => new FieldError(field, error));
-        return errors;
-      })
+      .map(field => field.mappedErrors)
       .reduce((accum, errorsArr) => [...accum, ...errorsArr], []);
     return fieldErrors;
   }

--- a/src/forms/index.js
+++ b/src/forms/index.js
@@ -1,6 +1,7 @@
 const { form } = require('./form');
 const { field } = require('./field');
 const { ref } = require('./ref');
+const { compoundField, errorFor } = require('./compoundField');
 const parsers = require('./fieldParsers');
 
 const arrayField = name => field(name, parsers.arrayParser);
@@ -22,5 +23,7 @@ module.exports = {
   arrayField,
   textField,
   nonEmptyTextField,
-  boolField
+  boolField,
+  compoundField,
+  errorFor
 };

--- a/src/forms/index.js
+++ b/src/forms/index.js
@@ -1,21 +1,14 @@
 const { form } = require('./form');
 const { field } = require('./field');
-const { ref } = require('./ref');
 const { compoundField, errorFor } = require('./compoundField');
-const parsers = require('./fieldParsers');
 
-const arrayField = name => field(name, parsers.arrayParser);
-arrayField.ref = (step, name) => ref(step, name, parsers.arrayParser);
+const {
+  arrayField,
+  textField,
+  nonEmptyTextField,
+  boolField
+} = require('./simpleFields');
 
-const textField = name => field(name, parsers.textParser);
-textField.ref = (step, name) => ref(step, name, parsers.textParser);
-
-const nonEmptyTextField = name => field(name, parsers.nonEmptyTextParser);
-nonEmptyTextField.ref = (step, name) =>
-  ref(step, name, parsers.nonEmptyTextParser);
-
-const boolField = name => field(name, parsers.boolParser);
-boolField.ref = (step, name) => ref(step, name, parsers.boolParser);
 
 module.exports = {
   form,

--- a/src/forms/index.js
+++ b/src/forms/index.js
@@ -9,6 +9,7 @@ const {
   boolField
 } = require('./simpleFields');
 
+const dateField = require('./complex/dateField');
 
 module.exports = {
   form,
@@ -18,5 +19,6 @@ module.exports = {
   nonEmptyTextField,
   boolField,
   compoundField,
-  errorFor
+  errorFor,
+  dateField
 };

--- a/src/forms/simpleFields.js
+++ b/src/forms/simpleFields.js
@@ -1,0 +1,23 @@
+const parsers = require('./fieldParsers');
+const { field } = require('./field');
+const { ref } = require('./ref');
+
+const arrayField = name => field(name, parsers.arrayParser);
+arrayField.ref = (step, name) => ref(step, name, parsers.arrayParser);
+
+const textField = name => field(name, parsers.textParser);
+textField.ref = (step, name) => ref(step, name, parsers.textParser);
+
+const nonEmptyTextField = name => field(name, parsers.nonEmptyTextParser);
+nonEmptyTextField.ref = (step, name) =>
+  ref(step, name, parsers.nonEmptyTextParser);
+
+const boolField = name => field(name, parsers.boolParser);
+boolField.ref = (step, name) => ref(step, name, parsers.boolParser);
+
+module.exports = {
+  arrayField,
+  textField,
+  nonEmptyTextField,
+  boolField
+};

--- a/src/util/checks.js
+++ b/src/util/checks.js
@@ -7,4 +7,18 @@ const ensureArray = maybeArray => {
   return [maybeArray];
 };
 
-module.exports = { notDefined, defined, ensureArray };
+const hasKey = (obj, key) => Object.getOwnPropertyNames(obj).includes(key);
+
+const hasKeys = (obj, ...keys) => keys.reduce(
+  (result, key) => result && hasKey(obj, key),
+  true
+);
+
+const isObject = maybeObj => typeof maybeObj === 'object';
+
+module.exports = {
+  notDefined, defined,
+  ensureArray,
+  hasKey, hasKeys,
+  isObject
+};

--- a/test/forms/compoundField.test.js
+++ b/test/forms/compoundField.test.js
@@ -1,0 +1,134 @@
+const { expect } = require('../util/chai');
+const CompoundField = require('../../src/forms/compoundField');
+const { textField } = require('../../src/forms');
+const Joi = require('joi');
+
+describe('forms/CompoundField', () => {
+  it('attaches each field to CompoundField.[field name]', () => {
+    const day = textField('day');
+    const month = textField('month');
+    const year = textField('year');
+    const date = new CompoundField('date', day, month, year);
+
+    expect(date.day).to.eql(day);
+    expect(date.month).to.eql(month);
+    expect(date.year).to.eql(year);
+  });
+
+  describe('#parse', () => {
+    it("fills it's child fields from the given body", () => {
+      const body = {
+        day: '6',
+        month: '12',
+        year: '2017'
+      };
+      const date = new CompoundField('date',
+        textField('day'),
+        textField('month'),
+        textField('year')
+      );
+
+      date.parse(body);
+      expect(date.day.value).to.eql(body.day);
+      expect(date.month.value).to.eql(body.month);
+      expect(date.year.value).to.eql(body.year);
+    });
+  });
+
+  describe('#deserialize', () => {
+    it('deserializes the field from the session', () => {
+      const session = {
+        date: {
+          day: '6',
+          month: '12',
+          year: '2017'
+        }
+      };
+      const date = new CompoundField('date',
+        textField('day'),
+        textField('month'),
+        textField('year')
+      );
+      date.deserialize(session);
+      expect(date.day.value).to.eql(session.date.day);
+      expect(date.month.value).to.eql(session.date.month);
+      expect(date.year.value).to.eql(session.date.year);
+    });
+  });
+
+  describe('#serialize', () => {
+    it("serializes it's child fields in to an object", () => {
+      const date = new CompoundField('date',
+        textField('day'),
+        textField('month'),
+        textField('year')
+      );
+      date.day.value = '6';
+      date.month.value = '12';
+      date.year.value = '2017';
+
+      const obj = date.serialize();
+      expect(obj).to.eql({ date: { day: '6', month: '12', year: '2017' } });
+    });
+  });
+
+  describe('#validate', () => {
+    it('returns true if validations pass', () => {
+      const date = new CompoundField('date',
+        textField('day').joi('day error', Joi.number()),
+        textField('month').joi('month error', Joi.number()),
+        textField('year').joi('year error', Joi.number())
+      ).joi('date error', Joi.object().and('day', 'month', 'year'));
+
+      date.parse({ day: 1, month: 12, year: 1988 });
+      expect(date.validate()).to.be.true;
+    });
+
+    it("returns false if it's validations fail", () => {
+      const parentWillFail = new CompoundField(
+        'parent',
+        textField('child')
+      ).joi('will fail', Joi.object().keys({ child: Joi.required() }));
+
+      expect(parentWillFail.validate()).to.be.false;
+    });
+
+    it('returns false if a child field validation fails', () => {
+      const childWillFail = new CompoundField(
+        'parent',
+        textField('child').joi('will fail', Joi.required())
+      );
+
+      expect(childWillFail.validate()).to.be.false;
+    });
+
+    it('executes any validations on the child fields', () => {
+      const error = name => `${name} is required`;
+
+      const date = new CompoundField('date',
+        textField('day').joi(error('day'), Joi.number().required()),
+        textField('month').joi(error('month'), Joi.number().required()),
+        textField('year').joi(error('year'), Joi.number().required())
+      );
+      date.validate();
+      expect(date.day.errors).to.contain(error('day'));
+      expect(date.month.errors).to.contain(error('month'));
+      expect(date.year.errors).to.contain(error('year'));
+    });
+
+    it("executes it's validations", () => {
+      const date = new CompoundField('date',
+        textField('day'),
+        textField('month'),
+        textField('year')
+      ).joi(
+        'A date is required',
+        Joi.object().and('day', 'month', 'year')
+      );
+
+      date.parse({ day: 10 });
+      date.validate();
+      expect(date.errors).to.contain('A date is required');
+    });
+  });
+});

--- a/test/forms/compoundField.test.js
+++ b/test/forms/compoundField.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('../util/chai');
-const CompoundField = require('../../src/forms/compoundField');
+const { CompoundField, errorFor } = require('../../src/forms/compoundField');
 const { textField } = require('../../src/forms');
 const Joi = require('joi');
 
@@ -129,6 +129,23 @@ describe('forms/CompoundField', () => {
       date.parse({ day: 10 });
       date.validate();
       expect(date.errors).to.contain('A date is required');
+    });
+
+    it('attaches a targeted error to the correct child field', () => {
+      const date = new CompoundField('date',
+        textField('day'),
+        textField('month'),
+        textField('year')
+      ).joi(
+        errorFor('day', 'Day is required'),
+        Joi.object()
+          .with('year', 'day')
+          .with('month', 'day')
+      );
+
+      date.parse({ year: 2017 });
+      date.validate();
+      expect(date.day.errors).to.contain('Day is required');
     });
   });
 });

--- a/test/forms/field.test.js
+++ b/test/forms/field.test.js
@@ -1,6 +1,7 @@
 const { expect, sinon } = require('../util/chai');
 const Joi = require('joi');
 const { field, FieldDesriptor } = require('../../src/forms/field');
+const FieldError = require('../../src/forms/fieldError');
 const { nonEmptyTextParser } = require('../../src/forms/fieldParsers');
 
 describe('forms/field', () => {
@@ -163,6 +164,24 @@ describe('forms/field', () => {
           .joi('Will Fail', Joi.string().required());
         nameField.validate();
         expect(nameField.errors).to.eql(['Will Fail']);
+      });
+    });
+
+    describe('#mappedErrors', () => {
+      it('returns [] if validations passed', () => {
+        const nameField = new FieldDesriptor('name')
+          .joi('Will Pass', Joi.any());
+        nameField.validate();
+        expect(nameField.mappedErrors).to.eql([]);
+      });
+
+      it('returns FieldErrors for each error', () => {
+        const nameField = new FieldDesriptor('name')
+          .joi('Will Fail', Joi.string().required());
+        nameField.validate();
+        expect(nameField.mappedErrors).to.eql(
+          [new FieldError(nameField, 'Will Fail')]
+        );
       });
     });
 

--- a/test/forms/fieldParsers.test.js
+++ b/test/forms/fieldParsers.test.js
@@ -39,6 +39,8 @@ describe('forms/fieldParsers', () => {
       name: 'textParser',
       parse: [
         { to: undefined },
+        { to: undefined, from: '' },
+        { to: undefined, from: null },
         { to: 'value', from: 'value' },
         { to: '1', from: 1 }
       ],


### PR DESCRIPTION
This PR adds a new base field class, the CompoundField, which can be used to collect mutliple fields and map them to one value.

In the demo app we use this to capture a date.

**Compound validations**

In compound fields you may want to validate the whole object but attach errors to specific fields inside the compound. To do this you can provide an `errorFor` instead of an error message as the first argument to validation functions (like `joi`). The first argument of `errorFor` indicates which subfield the error should be attached to and the second is the error mesage.
```
compoundField('date',
  textField('day'),
  textField('month'),
  textField('year'),
).joi(
  errorFor('day', 'Enter a day'),
  Joi.object()
     .with('year', 'day')
     .with('month', 'day')
)
```

**Mapping the value**

You can map the value from the compound field, which is very useful for when making complex checks in your `next` functions:

```
  get form() {
    return form(
      dateField('date').mapValue(
        ({ day, month, year }) => moment({ day, month, year })
      )
    );
  }

  next() {
    const oneYearAgo = moment().subtract(1, 'year');
    const marriedLessThan1Year = this.fields.date.value.isAfter(oneYearAgo);

    return branch(
      goTo(this.journey.steps.ExitDate).if(marriedLessThan1Year),
      goTo(this.journey.steps.Country)
    );
  }
```

It's worth noting that this mapping is applied only when you call the fields value, and so it is not stored in session. Also any validations will be applied to the raw field values instead of the mapped values.