### PR TITLE
Fix #77 by always waiting for a promises to complete

### DIFF
--- a/src/steps/Page.js
+++ b/src/steps/Page.js
@@ -42,7 +42,7 @@ class Page extends BaseStep {
   }
 
   get middleware() {
-    return [resolveTemplate, addLocals];
+    return [...super.middleware, resolveTemplate, addLocals];
   }
 
   get locals() {


### PR DESCRIPTION
This possibly will fix #77. 

#77 details an issue with content not loading correctly. This may fix this issue by ensuring that Pages actually wait for it's promises before handling the request. Pages were not waiting as the middleware that waits was declared in BaseStep and Page was redefining the `middleware` function without including a `super` call.

This would have cascaded to Questions, meaning that whether the content loads was mainly dependent on hoping the request took longer than the promise took to resolve.

I can't :100: guarantee this fixes it but I haven't been able to replicate since this change.