### PR TITLE
Filter ref fields out of default values

### DIFF
--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -6,6 +6,7 @@ const { METHOD_NOT_ALLOWED } = require('http-status-codes');
 const answer = require('./check-your-answers/answer');
 const formProxyHandler = require('../forms/formProxyHandler');
 const { form } = require('../forms');
+const { Reference } = require('../forms/ref');
 const logging = require('@log4js-node/log4js-api');
 const { ifCompleteThenContinue } = require('../flow/treeWalker');
 
@@ -50,6 +51,7 @@ class Question extends Page {
 
   values() {
     return Object.values(this.fields)
+      .filter(field => !(field instanceof Reference))
       .reduce((values, field) =>
         Object.assign(values, { [field.name]: field.value }), {}
       );

--- a/test/steps/Question.test.js
+++ b/test/steps/Question.test.js
@@ -2,7 +2,7 @@ const { expect, sinon } = require('../util/chai');
 const { testStep } = require('../util/supertest');
 const Question = require('../../src/steps/Question');
 const { section } = require('../../src/steps/check-your-answers/section');
-const { field, form } = require('../../src/forms');
+const { field, form, textField } = require('../../src/forms');
 const { goTo } = require('../../src/flow');
 const { METHOD_NOT_ALLOWED } = require('http-status-codes');
 const Joi = require('joi');
@@ -154,6 +154,30 @@ describe('steps/Question', () => {
         const _values = step.values();
         expect(_values).to.be.an('object');
         expect(_values).to.have.property('name', 'John');
+      });
+
+      it("doesn't include ref fields", () => {
+        const NameStep = class extends SimpleQuestion {
+          static get path() {
+            return '/next-step';
+          }
+          get form() {
+            return form(
+              textField.ref(this.journey.steps.NameStep, 'name')
+            );
+          }
+        };
+        const req = {
+          journey: { steps: { NameStep } },
+          session: { NameStep: { name: 'John' } }
+        };
+        const res = {};
+        const step = new NameStep(req, res);
+        step.retrieve().validate();
+
+        const _values = step.values();
+        expect(_values).to.be.an('object');
+        expect(_values).to.not.have.property('name', 'John');
       });
     });
 


### PR DESCRIPTION
Fixes #74.

This PR filters ref fields out of the default values of a step on the basis that they would be included in the values object by the step that captured them. Without this you need to explicitly set the values object on any steps where you use references.