### PR TITLE
Fix wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+<a name="2.0.0"></a>
+# 2.0.0 (2017-12-21)
+
+* Add a list field that wraps other fields ([f2a8743](https://github.com/hmcts/one-per-page/commit/f2a8743))
+* Add bool.default for setting the default value ([9cf17e0](https://github.com/hmcts/one-per-page/commit/9cf17e0))
+* Add convert to map values from one form to another ([e2bfa8c](https://github.com/hmcts/one-per-page/commit/e2bfa8c))
+* Allow only running specific tests (it.only) ([0238b34](https://github.com/hmcts/one-per-page/commit/0238b34))
+* Allow users of FieldDescriptor to change what value field it produces ([628e1df](https://github.com/hmcts/one-per-page/commit/628e1df))
+* Collect FieldValue classes in same module ([e5d6efb](https://github.com/hmcts/one-per-page/commit/e5d6efb))
+* Collect some common reduce and map operations to reuse them easier ([b05e394](https://github.com/hmcts/one-per-page/commit/b05e394))
+* Consume new fields for all basic fields ([a47b691](https://github.com/hmcts/one-per-page/commit/a47b691))
+* Demo validating a fields converted value ([c0a6eb7](https://github.com/hmcts/one-per-page/commit/c0a6eb7))
+* Enable object field validation and mapping errors ([7ae9660](https://github.com/hmcts/one-per-page/commit/7ae9660))
+* Ensure that transformed object fields still expose their child fields ([ad1821e](https://github.com/hmcts/one-per-page/commit/ad1821e))
+* Expose new field interfaces ([2bbd1d6](https://github.com/hmcts/one-per-page/commit/2bbd1d6))
+* Prevent mutating the base field descriptor ([744f7a4](https://github.com/hmcts/one-per-page/commit/744f7a4))
+* Provide mappedErrors needed for summarising the errors ([f56c80a](https://github.com/hmcts/one-per-page/commit/f56c80a))
+* Refactor compoundField to subclass from FieldDescriptor ([61a74a2](https://github.com/hmcts/one-per-page/commit/61a74a2))
+* Refactor fieldDescriptor so you can return FieldValue from your functions ([e4fb96d](https://github.com/hmcts/one-per-page/commit/e4fb96d))
+* Reimplement compoundField as object fieldDescriptor ([34e8046](https://github.com/hmcts/one-per-page/commit/34e8046))
+* Reimplement date field using new convert and object fields ([0e7ec76](https://github.com/hmcts/one-per-page/commit/0e7ec76))
+* Reimplement Form to support new field approach ([cc69e6b](https://github.com/hmcts/one-per-page/commit/cc69e6b))
+* Reimplement ref field in new approach ([b34f89b](https://github.com/hmcts/one-per-page/commit/b34f89b))
+* Remove complexity from mapping the entries in an object ([a771d17](https://github.com/hmcts/one-per-page/commit/a771d17))
+* Remove now unused formProxyHandler ([854f20f](https://github.com/hmcts/one-per-page/commit/854f20f))
+* Remove value from answers block as its not used anymore ([b20a352](https://github.com/hmcts/one-per-page/commit/b20a352))
+* Rename underlying field to better describe it ([18d78ae](https://github.com/hmcts/one-per-page/commit/18d78ae))
+* Replace old form interface with our new one ([f199ce9](https://github.com/hmcts/one-per-page/commit/f199ce9))
+* Rewrite fields to separate declaration of a field and the parsed value ([0cd434e](https://github.com/hmcts/one-per-page/commit/0cd434e))
+* Simplify cloning a field descriptor ([e55de7b](https://github.com/hmcts/one-per-page/commit/e55de7b))
+* Split fieldValue.test.js as it was too long ([340ca08](https://github.com/hmcts/one-per-page/commit/340ca08))
+* Split FilledForm and Form in to their own packages ([17888e6](https://github.com/hmcts/one-per-page/commit/17888e6))
+* Test date field ([009cfec](https://github.com/hmcts/one-per-page/commit/009cfec))
+* Update list to parse from BodyParsers output ([66e5e2c](https://github.com/hmcts/one-per-page/commit/66e5e2c))
+* Fix: Moment accepts months 0-indexed but parses them as you'd expect ([0f91129](https://github.com/hmcts/one-per-page/commit/0f91129))
+
+
+
 <a name="2.0.0-5"></a>
 # 2.0.0-5 (2017-12-13)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
-  "version": "2.0.0-5",
+  "version": "2.0.0",
   "main": "./src/main.js",
   "dependencies": {
     "@log4js-node/log4js-api": "^1.0.0",

--- a/src/forms/fieldValue.js
+++ b/src/forms/fieldValue.js
@@ -133,9 +133,13 @@ class ListFieldValue extends ObjectFieldValue {
 }
 
 class TransformFieldValue extends FieldValue {
-  constructor({ transformation, field, validations = [] }) {
-    super({ name: field.name, id: field.id, serializer: field.serializer });
-    this.wrapped = field;
+  constructor({ transformation, wrapped, validations = [] }) {
+    super({
+      name: wrapped.name,
+      id: wrapped.id,
+      serializer: wrapped.serializer
+    });
+    this.wrapped = wrapped;
     this.transformation = transformation;
     this.validations = validations;
 

--- a/src/forms/fields.js
+++ b/src/forms/fields.js
@@ -161,14 +161,16 @@ const ref = (step, field) => fieldDescriptor({
 
 const convert = (transformation, field) => fieldDescriptor({
   parser(name, body, req) {
+    const fieldValue = field.parse(name, body, req);
     return TransformFieldValue.from(
-      { transformation, field: field.parse(name, body, req) },
+      { transformation, wrapped: fieldValue },
       this
     );
   },
   deserializer(name, values, req) {
+    const fieldValue = field.deserialize(name, values, req);
     return TransformFieldValue.from(
-      { transformation, field: field.deserialize(name, values, req) },
+      { transformation, wrapped: fieldValue },
       this
     );
   }

--- a/test/forms/fieldValues/transformFieldValue.test.js
+++ b/test/forms/fieldValues/transformFieldValue.test.js
@@ -11,24 +11,24 @@ describe('forms/fieldValue', () => {
   describe('TransformFieldValue', () => {
     {
       const transformation = f => f;
-      const field = new FieldValue({ name: 'field', value: 'foo' });
-      const t = new TransformFieldValue({ transformation, field });
+      const wrapped = new FieldValue({ name: 'field', value: 'foo' });
+      const t = new TransformFieldValue({ transformation, wrapped });
 
       it('accepts a field and a transformation function', () => {
-        expect(t.wrapped).to.eql(field);
+        expect(t.wrapped).to.eql(wrapped);
         expect(t.transformation).to.eql(transformation);
       });
 
       it('takes its name and id from the field', () => {
-        expect(t.name).to.eql(field.name);
-        expect(t.id).to.eql(field.id);
+        expect(t.name).to.eql(wrapped.name);
+        expect(t.id).to.eql(wrapped.id);
       });
 
       it('exposes any child fields the field has', () => {
-        const objectField = new ObjectFieldValue({ fields: { foo: field } });
+        const objectField = new ObjectFieldValue({ fields: { foo: wrapped } });
         const nested = new TransformFieldValue({
           transformation,
-          field: objectField
+          wrapped: objectField
         });
         expect(nested).to.have.property('foo');
         expect(nested.foo).to.eql(objectField.foo);
@@ -38,10 +38,10 @@ describe('forms/fieldValue', () => {
     describe('#serialize', () => {
       it('calls field.serialize', () => {
         const transformation = f => f;
-        const field = { serialize: sinon.stub().returns({}) };
-        const t = new TransformFieldValue({ transformation, field });
+        const wrapped = { serialize: sinon.stub().returns({}) };
+        const t = new TransformFieldValue({ transformation, wrapped });
         expect(t.serialize()).to.eql({});
-        expect(field.serialize).calledOnce;
+        expect(wrapped.serialize).calledOnce;
       });
     });
 
@@ -62,7 +62,7 @@ describe('forms/fieldValue', () => {
 
         const t = new TransformFieldValue({
           transformation: toArray,
-          field,
+          wrapped: field,
           validations: [arrayCheck]
         });
 
@@ -78,7 +78,10 @@ describe('forms/fieldValue', () => {
           name: 'field', value: '1,2,3',
           validate: sinon.stub().returns(true)
         };
-        const t = new TransformFieldValue({ transformation: v => v, field });
+        const t = new TransformFieldValue({
+          transformation: v => v,
+          wrapped: field
+        });
 
         expect(t.validate()).to.eql(true);
         expect(field.validate).calledOnce;
@@ -90,7 +93,7 @@ describe('forms/fieldValue', () => {
 
         const t = new TransformFieldValue({
           transformation: v => v,
-          field,
+          wrapped: field,
           validations: [notRun]
         });
 
@@ -104,7 +107,7 @@ describe('forms/fieldValue', () => {
         const field = { value: 'John Smith' };
         const t = new TransformFieldValue({
           transformation: sinon.stub().returns('foo'),
-          field
+          wrapped: field
         });
         expect(t.value).to.not.eql(field.value);
         expect(t.transformation).calledOnce;
@@ -123,7 +126,7 @@ describe('forms/fieldValue', () => {
         const willFail = validator('field', 'from transformed', () => false);
         const t = new TransformFieldValue({
           transformation: sinon.stub().returns('foo'),
-          field,
+          wrapped: field,
           validations: [willFail]
         });
         t.validate();
@@ -141,7 +144,7 @@ describe('forms/fieldValue', () => {
         const transformedErr = validator('f', 'from transformed', () => false);
         const t = new TransformFieldValue({
           transformation: sinon.stub().returns('foo'),
-          field,
+          wrapped: field,
           validations: [transformedErr]
         });
         t.validate();
@@ -168,7 +171,7 @@ describe('forms/fieldValue', () => {
       it('returns true if it and field are valid', () => {
         const t = new TransformFieldValue({
           transformation,
-          field: validField,
+          wrapped: validField,
           validations: [willPass]
         });
         t.validate();
@@ -178,7 +181,7 @@ describe('forms/fieldValue', () => {
       it('returns false if it is not valid', () => {
         const t = new TransformFieldValue({
           transformation,
-          field: validField,
+          wrapped: validField,
           validations: [willFail]
         });
         t.validate();
@@ -188,7 +191,7 @@ describe('forms/fieldValue', () => {
       it('returns false if the field is not valid', () => {
         const t = new TransformFieldValue({
           transformation,
-          field: invalidField,
+          wrapped: invalidField,
           validations: [willPass]
         });
         t.validate();
@@ -211,7 +214,7 @@ describe('forms/fieldValue', () => {
       it('returns true if it and field have been validated', () => {
         const t = new TransformFieldValue({
           transformation,
-          field: validatedField,
+          wrapped: validatedField,
           validations: [willPass]
         });
         t.validate();
@@ -221,7 +224,7 @@ describe('forms/fieldValue', () => {
       it('returns false if it has not been validated', () => {
         const t = new TransformFieldValue({
           transformation,
-          field: notValidatedField,
+          wrapped: notValidatedField,
           validations: [willPass]
         });
         expect(t.validated).to.be.false;


### PR DESCRIPTION
This PR fixes a bug found in 2.0.0 that was caused by renaming the field parameter in TransformFieldValue to wrapped. This meant that cloning the TransformFieldValue would cause it to lose it's wrapped field, which happens when you do something like: `list(convert(..., text))` or `object({ foo: convert(...) })`.