### PR TITLE
Allow developers to set custom timeouts

### DIFF
--- a/docs/steps/BaseStep.md
+++ b/docs/steps/BaseStep.md
@@ -63,6 +63,34 @@ class MyStep extends BaseStep {
 }
 ```
 
+### Custom step timeouts
+
+Registering a promise may cause a step to take longer than the standard timeout.
+
+You can set a timeout to wait for a specific step by overriding
+[`get timeoutDelay()`](#get-timeoutdelay):
+
+```js
+class MyStep extends BaseStep {
+  constructor(...args) {
+    super(...args);
+    this.waitFor(veryLongRunningProcess);
+  }
+  get timeoutDelay() {
+    return 500;
+  }
+}
+```
+
+You can set a global timeout delay when creating your journey:
+
+```js
+journey(app, {
+  steps: [ ... ],
+  timeoutDelay: 500
+});
+```
+
 -------------------------------------------------------------------------------
 
 ## API
@@ -109,6 +137,33 @@ steps created by `collectSteps` will not handle the request.
 
 Anything you need to execute for each request and when being collected for
 Check your Answers should be implemented as a Promise.
+
+### `get timeoutDelay()`
+
+- __Returns__ a number, the milliseconds to wait for promises to resolve
+
+Used in [`ready()`](#ready) to wait until promises resolve or to timeout.
+
+Will return `50` if no global `timeoutDelay` is set. You can set a global
+timeout delay when creating your journey:
+
+```js
+journey(app, {
+  steps: [ ... ],
+  timeoutDelay: 500
+});
+```
+
+Overriding this function allows you to set a step specific timeout:
+
+```js
+class MyStep extends BaseStep {
+  get timeoutDelay() {
+    return 500;
+  }
+}
+```
+
 
 ### `ready()`
 

--- a/src/steps/BaseStep.js
+++ b/src/steps/BaseStep.js
@@ -7,8 +7,9 @@ const { defined, notDefined } = require('../util/checks');
 const logging = require('@log4js-node/log4js-api');
 const { timeout } = require('../util/promises');
 const errorIfNotReady = require('../middleware/errorIfNotReady');
+const { fromNullable } = require('option');
 
-const MAX_WAIT_MS = 50;
+const DEFAULT_WAIT_MS = 50;
 
 const findChildClassFilePath = step => {
   const callsite = callsites();
@@ -36,8 +37,14 @@ class BaseStep {
     this.promises.push(promise);
   }
 
+  get timeoutDelay() {
+    return fromNullable(this.journey.settings)
+      .flatMap(settings => fromNullable(settings.timeoutDelay))
+      .valueOrElse(DEFAULT_WAIT_MS);
+  }
+
   ready() {
-    return timeout(MAX_WAIT_MS, Promise.all(this.promises))
+    return timeout(this.timeoutDelay, Promise.all(this.promises))
       .then(() => this);
   }
 


### PR DESCRIPTION
Closes #89 and #87. 

This PR allows developers to set the global and step specific timeouts.

Documentation on how to use this feature is included in the PR and will be available at [Custom step timeouts](https://one-per-page.herokuapp.com/docs/steps/BaseStep#custom-step-timeouts) when merged.