### PR TITLE
Better refs

### DIFF
--- a/docs/forms/field-types.md
+++ b/docs/forms/field-types.md
@@ -18,6 +18,18 @@ form({
 });
 ```
 
+### `text.ref(step, fieldName)`
+
+Loads a text field from another step.
+
+> See [`ref(step, field, fieldName)`] for more information.
+
+```js
+form({
+  appType: text.ref(this.journey.steps.ApplicationType, 'applicationType')
+});
+```
+
 ## `nonEmptyText`
 
 > `const { nonEmptyText } = require('@hmcts/one-per-page/forms');`
@@ -27,9 +39,25 @@ NonEmptyText fields are fields that will parse a missing key to an empty string
 
 ```js
 form({
-  isCitizen: ref(this.journey.steps.CitizenCheck, 'isCitizen')
+  firstName: nonEmptyText,
+  lastName: nonEmptyText
 });
 ```
+
+### `nonEmptyText.ref(step, fieldName)`
+
+Loads a nonEmptyText field from another step.
+
+> See [`ref(step, field, fieldName)`] for more information.
+
+```js
+form({
+  appType: nonEmptyText.ref(this.journey.steps.ApplicationType, 'applicationType')
+});
+```
+
+This will load `applicationType` from the `ApplicationType` step and will be
+available to you on `this.fields.appType`.
 
 ## `bool`
 
@@ -62,7 +90,19 @@ form({
 });
 ```
 
-## `ref(step, fieldName)`
+### `bool.ref(step, fieldName)`
+
+Loads a bool field from another step.
+
+> See [`ref(step, field, fieldName)`] for more information.
+
+```js
+form({
+  contact: bool.ref(this.journey.steps.ContactPreference, 'contactMe')
+});
+```
+
+## `ref(step, field, fieldName)`
 
 > `const { ref } = require('@hmcts/one-per-page/forms');`
 
@@ -92,6 +132,18 @@ validations to the wrapped field type.
 form({
   names: list(text)
 })
+```
+
+### `list.ref(step, fieldName, fieldType)`
+
+Loads a list field from another step.
+
+> See [`ref(step, field, fieldName)`] for more information.
+
+```js
+form({
+  names: list.ref(this.journey.steps.NameStep, 'names', text)
+});
 ```
 
 ## `object({ [name]: [field type] })`
@@ -134,6 +186,21 @@ filled.nested.value
 filled.nested.field.value
 // 'foo'
 
+```
+
+### `object.ref(step, fieldName, { [field name]: [field type] })`
+
+Loads a object field from another step.
+
+> See [`ref(step, field, fieldName)`] for more information.
+
+```js
+form({
+  petitioner: object.ref(this.journey.steps.PetitionerDetails, 'peitioner', {
+    firstName: text,
+    lastName: text
+  })
+});
 ```
 
 ## `convert(transformation, field)`
@@ -202,3 +269,4 @@ messages:
 
 [`FieldDescriptor`]: /docs/forms/internal-api/FieldDescriptor
 [date-pattern]: https://govuk-elements.herokuapp.com/form-elements/example-date/
+[`ref(step, field, fieldName)`]: #ref-step-field-fieldname

--- a/examples/test-app/steps/Name.step.js
+++ b/examples/test-app/steps/Name.step.js
@@ -14,7 +14,10 @@ class Name extends Question {
         this.content.fields.lastName.required,
         Joi.string().required()
       ),
-      husbandOrWife: ref(this.journey.steps.RespondentTitle, text),
+      husbandOrWife: text.ref(
+        this.journey.steps.RespondentTitle,
+        'husbandOrWife'
+      ),
       respondentFirstName: text.joi(
         this.content.fields.respondentFirstName.required,
         Joi.string().required()

--- a/test/forms/fields.test.js
+++ b/test/forms/fields.test.js
@@ -274,14 +274,79 @@ describe('forms/fields', () => {
     });
   }));
 
-  const myStep = { name: 'MyStep' };
-  describe('ref([step], text)', fieldTest(ref(myStep, text), it => {
-    const req = { session: { MyStep: { foo: 'From another step' } } };
+  {
+    const myStep = { name: 'MyStep' };
+    const session = {
+      MyStep: {
+        listKey: ['Foo', 'Bar', 'Baz'],
+        objectKey: {
+          a: 'A text field',
+          b: true
+        },
+        nonEmptyKey: 'From another step',
+        textKey: 'From another step',
+        boolKey: true
+      }
+    };
 
-    it.parses({ to: 'From another step', req });
-    it.deserializes({ value: 'From another step', req });
-    it.serializes({ to: {}, from: {}, req });
-  }));
+    describe('ref([step], text)', fieldTest(ref(myStep, text), it => {
+      const req = { session: { MyStep: { foo: 'From another step' } } };
+
+      it.parses({ to: 'From another step', req });
+      it.deserializes({ value: 'From another step', req });
+      it.serializes({ to: {}, from: {}, req });
+    }));
+
+    const objectRef = object.ref(myStep, 'objectKey', { a: text, b: bool });
+    describe('object.ref([step], [key], [fields])', fieldTest(objectRef, it => {
+      const req = { session };
+      it.parses({ to: { a: 'A text field', b: true }, req });
+      it.deserializes({ value: { a: 'A text field', b: true }, req });
+      it.serializes({ to: {}, from: {}, req });
+    }));
+
+    const listRef = list.ref(myStep, 'listKey', text);
+    describe('list.ref([step], [key], text)', fieldTest(listRef, it => {
+      const req = { session };
+
+      it.parses({ to: ['Foo', 'Bar', 'Baz'], req });
+      it.deserializes({ value: ['Foo', 'Bar', 'Baz'], req });
+      it.serializes({ to: {}, from: {}, req });
+    }));
+
+    const nonEmptyRef = nonEmptyText.ref(myStep, 'nonEmptyKey');
+    describe('nonEmptyText.ref([step], [key])', fieldTest(nonEmptyRef, it => {
+      const req = { session };
+      it.parses({ to: 'From another step', req });
+      it.parses({ to: '', req: {} });
+
+      it.deserializes({ value: 'From another step', req });
+      it.deserializes({ value: '', req: {} });
+
+      it.serializes({ to: {}, from: {}, req });
+    }));
+
+    const textRef = text.ref(myStep, 'textKey');
+    describe('text.ref([step], [key])', fieldTest(textRef, it => {
+      const req = { session };
+      it.parses({ to: 'From another step', req });
+      it.parses({ to: undefined, req: {} });
+
+      it.deserializes({ value: 'From another step', req });
+      it.deserializes({ value: undefined, req: {} });
+
+      it.serializes({ to: {}, from: {}, req });
+    }));
+
+    const boolRef = bool.ref(myStep, 'boolKey');
+    describe('bool.ref([step], [key])', fieldTest(boolRef, it => {
+      const req = { session };
+      it.parses({ to: true, req });
+      it.deserializes({ value: true, req });
+      it.serializes({ to: {}, from: {}, req });
+    }));
+
+  }
 
   const toUpper = convert(str => str.toUpperCase(), text);
   describe('convert(() => {}, text)', fieldTest(toUpper, it => {


### PR DESCRIPTION
Feedback from SSCS has highlighted that the way of using `ref`, where you wrap a field with it, is confusing.

The reason behind it is that the ref uses the name of the field in the form to load from the other step. Which requires that both fields are named the same in both steps.

Where this breaks down is where you have a field captured multiple times on different steps with different context and want to refer to them in the same step:

```js
class PetitionerDetails extends Question {
  get form() {
    return form({
      name: text,
      dob: date
    });
  }
}
class RespondentDetails extends Question {
  get form() {
    return form({
      name: text,
      dob: date
    });
  }
}

class ReferringToOthers extends Question {
  get form() {
    return form({
      petitionerName: ref(this.journey.steps.PetitionerDetails, text),
      respondentName: ref(this.journey.steps.RespondentDetails, text)
    });
  }
}
```

The example above previously would have required that the name field in PetiionerDetails was `petitionerName`.

This PR adds an optional fieldname parameter to ref and adds `.ref` functions to the base steps, meaning we can now do:

```js
class ReferringToOthers extends Question {
  get form() {
    return form({
      petitionerName: ref(this.journey.steps.PetitionerDetails, text, 'name'),
      respondentName: text.ref(this.journey.steps.RespondentDetails, 'name')
    });
  }
}
```