### PR TITLE
Prevent browsers from caching Questions

### DIFF
--- a/src/forms/filledForm.js
+++ b/src/forms/filledForm.js
@@ -33,7 +33,7 @@ class FilledForm {
       .reduce(flattenObject, {});
 
     if (values !== {}) {
-      Object.assign(req.session, { [stepName]: values });
+      Object.assign(req.session, { [stepName]: values, temp: {} });
     }
   }
 

--- a/src/forms/filledForm.js
+++ b/src/forms/filledForm.js
@@ -37,6 +37,23 @@ class FilledForm {
     }
   }
 
+  tempStore(stepName, req) {
+    if (notDefined(req.session)) {
+      throw new Error('Session not initialized');
+    }
+    const existingValues = option
+      .fromNullable(req.session[stepName])
+      .valueOrElse({});
+
+    const values = Object.values(this.fields)
+      .map(field => field.serialize(existingValues))
+      .reduce(flattenObject, {});
+
+    if (values !== {}) {
+      Object.assign(req.session, { temp: { [stepName]: values } });
+    }
+  }
+
   validate() {
     return Object.values(this.fields)
       .map(field => field.validate())

--- a/src/forms/form.js
+++ b/src/forms/form.js
@@ -23,7 +23,15 @@ class Form {
     if (notDefined(req.session)) {
       throw new Error('Session not initialized');
     }
-    const values = option.fromNullable(req.session[stepName]).valueOrElse({});
+    const tempValues = option
+      .fromNullable(req.session.temp)
+      .flatMap(temp => option.fromNullable(temp[stepName]));
+    const storedValues = option
+      .fromNullable(req.session[stepName]);
+    const values = tempValues
+      .orElse(storedValues)
+      .valueOrElse({});
+
     const fieldValues = mapEntries(
       this.fields,
       (key, field) => field.deserialize(key, values, req)

--- a/src/middleware/preventCaching.js
+++ b/src/middleware/preventCaching.js
@@ -1,0 +1,7 @@
+const preventCaching = (req, res, next) => {
+  // Prevents caching of responses, to ensure a revalidate of the users answers
+  res.set('Cache-Control', 'no-cache, max-age=0, must-revalidate, no-store');
+  next();
+};
+
+module.exports = preventCaching;

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -82,14 +82,6 @@ class AddAnother extends Question {
     }
   }
 
-  renderPage() {
-    this.retrieve();
-    if (this.fields.isFilled) {
-      this.validate();
-    }
-    this.res.render(this.template, this.locals);
-  }
-
   listModeHandler(req, res) {
     if (req.method === 'GET') {
       this.renderPage();

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -23,10 +23,17 @@ class Question extends Page {
     ];
   }
 
+  renderPage() {
+    this.retrieve();
+    if (this.fields.isFilled) {
+      this.validate();
+    }
+    this.res.render(this.template, this.locals);
+  }
+
   handler(req, res) {
     if (req.method === 'GET') {
-      this.retrieve();
-      super.handler(req, res);
+      this.renderPage();
     } else if (req.method === 'POST') {
       this.parse();
       this.validate();
@@ -35,7 +42,8 @@ class Question extends Page {
         this.store();
         this.next().redirect(req, res);
       } else {
-        res.render(this.template, this.locals);
+        this.storeErrors();
+        res.redirect(this.path);
       }
     } else {
       res.sendStatus(METHOD_NOT_ALLOWED);
@@ -88,6 +96,11 @@ class Question extends Page {
 
   store() {
     this.fields.store(this.name, this.req);
+    return this;
+  }
+
+  storeErrors() {
+    this.fields.tempStore(this.name, this.req);
     return this;
   }
 

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -8,6 +8,7 @@ const { form } = require('../forms');
 const { Reference } = require('../forms/ref');
 const logging = require('@log4js-node/log4js-api');
 const { ifCompleteThenContinue } = require('../flow/treeWalker');
+const preventCaching = require('../middleware/preventCaching');
 
 class Question extends Page {
   constructor(...args) {
@@ -19,7 +20,8 @@ class Question extends Page {
     return [
       ...super.middleware,
       bodyParser.urlencoded({ extended: true }),
-      requireSession
+      requireSession,
+      preventCaching
     ];
   }
 

--- a/src/steps/check-your-answers/CheckYourAnswers.js
+++ b/src/steps/check-your-answers/CheckYourAnswers.js
@@ -2,7 +2,7 @@ const Question = require('../Question');
 const { section } = require('./section');
 const { defined } = require('../../../src/util/checks');
 const { validateThenStopHere } = require('../../flow');
-const { form, boolField } = require('../../forms');
+const { form, bool } = require('../../forms');
 const Joi = require('joi');
 
 class CheckYourAnswers extends Question {
@@ -20,12 +20,12 @@ class CheckYourAnswers extends Question {
   }
 
   get form() {
-    return form(
-      boolField('statementOfTruth').joi(
+    return form({
+      statementOfTruth: bool.joi(
         this.errorMessage,
         Joi.required().valid(true)
       )
-    );
+    });
   }
 
   get flowControl() {

--- a/test/forms/filledForm.test.js
+++ b/test/forms/filledForm.test.js
@@ -65,6 +65,26 @@ describe('forms/filledForm', () => {
       });
     });
 
+    describe('#tempStore', () => {
+      const fields = {
+        foo: text.parse('foo', { foo: 'A text value' }),
+        bar: text.parse('bar', { bar: 'Another text value' })
+      };
+
+      it('stores the serialized fields in the temp session', () => {
+        const f = new FilledForm(fields);
+        const req = { session: {} };
+
+        f.tempStore('StepName', req);
+
+        expect(req.session.temp).has.property('StepName');
+        expect(req.session.temp.StepName)
+          .has.property('foo', 'A text value');
+        expect(req.session.temp.StepName)
+          .has.property('bar', 'Another text value');
+      });
+    });
+
     describe('#validate', () => {
       const isValid = sinon.stub().returns(true);
       const isInvalid = sinon.stub().returns(false);

--- a/test/forms/form.test.js
+++ b/test/forms/form.test.js
@@ -101,6 +101,43 @@ describe('forms/form', () => {
         expect(filled.fields).to.have.property('bar')
           .that.has.property('value', 'Another text value');
       });
+
+      it('fetches temporary values from the session', () => {
+        const f = new Form({ foo: text, bar: text });
+        const req = {
+          session: {
+            temp: {
+              StepName: {
+                foo: 'A temporary value',
+                bar: 'Another temporary value'
+              }
+            }
+          }
+        };
+        const filled = f.retrieve('StepName', req);
+
+        expect(filled.fields)
+          .to.have.property('foo')
+          .that.has.property('value', 'A temporary value');
+        expect(filled.fields)
+          .to.have.property('bar')
+          .that.has.property('value', 'Another temporary value');
+      });
+
+      it('prefers temporary values over stored session values', () => {
+        const f = new Form({ foo: text });
+        const req = {
+          session: {
+            temp: { StepName: { foo: 'A temporary value' } },
+            StepName: { foo: 'A stored value' }
+          }
+        };
+        const filled = f.retrieve('StepName', req);
+
+        expect(filled.fields)
+          .to.have.property('foo')
+          .that.has.property('value', 'A temporary value');
+      });
     });
   });
 });


### PR DESCRIPTION
This PR prevents browsers from caching Questions. This ensures that when a user hits back the browser issues a fresh GET request and so the most up to date values are displayed (as documented in #68).

To do this we have added cache control headers that force a revalidation and changed how questions act under error. If the users input is not valid the answers will be stored in a temporary section in session and a 302 will be issued. The browser will then GET the page again and the users answers will be loaded from temp session and validated. The errors will then be rendered on the page.

This `temp session -> 302 -> GET -> load -> render errors` behaviour is required as if we render the errors on POST and prevent the browser from caching the response then when you hit back the browser will attempt to issue the POST request again.