### PR TITLE
Ensure refs aren't included in checking if an answer has been given

### DIFF
--- a/src/forms/fieldValue.js
+++ b/src/forms/fieldValue.js
@@ -226,6 +226,12 @@ class RefValue extends TransformFieldValue {
       serializer: returnNothing
     });
   }
+
+  get isFilled() {
+    // Refs shouldn't be considered when asking if the form has any values
+    // as these aren't values produced by this step
+    return false;
+  }
 }
 
 const fieldValue = args => new FieldValue(args);

--- a/test/forms/fieldValues/refValue.test.js
+++ b/test/forms/fieldValues/refValue.test.js
@@ -1,0 +1,22 @@
+const { expect } = require('../../util/chai');
+const { RefValue, FieldValue } = require('../../../src/forms/fieldValue');
+
+describe('forms/fieldValue', () => {
+  describe('RefValue', () => {
+    describe('#isFilled', () => {
+      it("always returns false (refs aren't values produced by steps)", () => {
+        const f = new FieldValue({ id: 'id', name: 'name', value: 'value' });
+        const ref = RefValue.wrap(f);
+        expect(ref.isFilled).to.be.false;
+      });
+    });
+
+    describe('#serialize', () => {
+      it('returns an empty object', () => {
+        const f = new FieldValue({ id: 'id', name: 'name', value: 'value' });
+        const ref = RefValue.wrap(f);
+        expect(ref.serialize()).to.eql({});
+      });
+    });
+  });
+});


### PR DESCRIPTION
Before this change, having a ref in a step would mean `form.isFilled`
would return true and so validation would be run on first visiting a
page.

Now refs aren't included in this check and so the validation is only
run on subsequent visits.