### PR TITLE
Content caching

### DIFF
--- a/src/i18n/loadStepContent.js
+++ b/src/i18n/loadStepContent.js
@@ -34,7 +34,7 @@ const loadFileContents = (filePath, i18Next) => {
     bundles.forEach(({ lang, translations }) => {
       const deep = true;
       const overwrite = true;
-      i18Next.addResourceBundle(
+      i18Next.addBundleIfModified(
         lang,
         'translation',
         translations,
@@ -56,7 +56,7 @@ const loadStepContent = (step, i18Next) => {
     bundles.forEach(({ lang, translations }) => {
       const deep = true;
       const overwrite = true;
-      i18Next.addResourceBundle(
+      i18Next.addBundleIfModified(
         lang,
         step.name,
         translations,

--- a/test/i18n/i18Next.test.js
+++ b/test/i18n/i18Next.test.js
@@ -155,5 +155,34 @@ describe('i18n/i18Next', () => {
       expect(i18NextInstance)
         .to.have.property('addResourceBundle').that.is.a('function');
     });
+
+    describe('#addBundleIfModified', () => {
+      beforeEach(() => {
+        sinon.spy(i18NextInstance, 'addResourceBundle');
+      });
+
+      afterEach(() => {
+        i18NextInstance.addResourceBundle.restore();
+      });
+
+      it('loads the resource bundle if not recognised', () => {
+        i18NextInstance.contentBundles = {};
+        const args = ['en', 'Step', { my: 'translations' }, true, true];
+
+        i18NextInstance.addBundleIfModified(...args);
+
+        expect(i18NextInstance.addResourceBundle).calledWith(...args);
+      });
+
+      it('wont load the resource bundle already loaded', () => {
+        i18NextInstance.contentBundles = {};
+        const args = ['en', 'Step', { my: 'translations' }, true, true];
+
+        i18NextInstance.addBundleIfModified(...args);
+        i18NextInstance.addBundleIfModified(...args);
+
+        expect(i18NextInstance.addResourceBundle).calledOnce;
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR speeds up steps by only loading a resource bundle if that bundle hasn't been loaded before. It does this by storing a hash of the translations on the i18Next instance and only calling `addResourceBundle` if the hash doesn't exist or doesn't match.