### PR TITLE
Clever flow control

### DIFF
--- a/examples/test-app/steps/exits/ExitNorthernIreland.step.js
+++ b/examples/test-app/steps/exits/ExitNorthernIreland.step.js
@@ -1,6 +1,6 @@
-const { Page } = require('@hmcts/one-per-page');
+const { ExitPoint } = require('@hmcts/one-per-page');
 
-class ExitNorthernIreland extends Page {
+class ExitNorthernIreland extends ExitPoint {
   static get path() {
     return '/exit/northern-ireland';
   }

--- a/examples/test-app/steps/exits/ExitNorthernIreland.template.html
+++ b/examples/test-app/steps/exits/ExitNorthernIreland.template.html
@@ -1,12 +1,7 @@
+{% extends "question-globals.njk" %}
 {% extends "look-and-feel/layouts/two_thirds.html" %}
 {% from "look-and-feel/components/header.njk" import header %}
-
-{% block head -%}
-<link href="{{ asset_path }}main.css" media="screen" rel="stylesheet" />
-{% endblock %}
-
-{% set phase="ALPHA" %}
-{% set feedbackLink="https://github.com/hmcts/one-per-page/issues/new" %}
+{% from "look-and-feel/components/phase_banner.njk" import phaseBanner %}
 
 {% block breadcrumbs %}
 {{ phaseBanner(phase, feedbackLink) }}
@@ -15,5 +10,9 @@
 {% block two_thirds %}
 
 {{ header(content.title) }}
+
+<p>This is an example exit page. Your session has been removed.</p>
+
+<p>If you click back you'll be redirected back to the start page.</p>
 
 {% endblock %}

--- a/src/flow/index.js
+++ b/src/flow/index.js
@@ -1,4 +1,5 @@
 const Redirector = require('./redirector');
+const SmartRedirector = require('./smartRedirector');
 const Branch = require('./branch');
 const Stop = require('./stop');
 const journey = require('./journey');
@@ -11,13 +12,15 @@ const {
   validateThenStopHere
 } = require('./treeWalker');
 
-const goTo = step => new Redirector(step);
+const goTo = step => new SmartRedirector(step);
+const redirectTo = step => new Redirector(step);
 const branch = (...redirectors) => new Branch(...redirectors);
 const stop = step => new Stop(step);
 const action = redirector => new Action(redirector);
 
 module.exports = {
   goTo,
+  redirectTo,
   branch,
   stop,
   action,

--- a/src/flow/smartRedirector.js
+++ b/src/flow/smartRedirector.js
@@ -1,0 +1,15 @@
+const Redirector = require('./redirector');
+
+class SmartRedirector extends Redirector {
+  redirect(req, res) {
+    const instance = req.journey.instance(this.nextStep);
+    try {
+      const nextStep = instance.flowControl.last();
+      res.redirect(nextStep.path);
+    } catch (error) {
+      throw new Error(`${instance.name} does not have a flowControl.`);
+    }
+  }
+}
+
+module.exports = SmartRedirector;

--- a/src/flow/treeWalker.js
+++ b/src/flow/treeWalker.js
@@ -20,6 +20,11 @@ class TreeWalker {
     return this.trampoline(this, step => step);
   }
 
+  last() {
+    const steps = this.walk();
+    return steps[steps.length - 1];
+  }
+
   // Trampolines are a way of doing recursion when your language doesn't support
   // tail call optimisation. Standard recursion would lead to the stack growing
   // to overflow.

--- a/test/flow/smartRedirector.test.js
+++ b/test/flow/smartRedirector.test.js
@@ -1,0 +1,39 @@
+const { expect, sinon } = require('../util/chai');
+const SmartRedirector = require('../../src/flow/smartRedirector');
+
+describe('flow/SmartRedirector', () => {
+  describe('#redirect', () => {
+    const fakeFlowControl = { last: sinon.stub() };
+    const fakeJourney = { instance: sinon.stub() };
+    const fakeStep = { path: '/foo', flowControl: fakeFlowControl };
+    const fakeRes = { redirect: sinon.stub() };
+    const fakeReq = { journey: fakeJourney };
+
+    beforeEach(() => {
+      fakeFlowControl.last.reset();
+      fakeJourney.instance.reset();
+      fakeRes.redirect.reset();
+    });
+
+    it('walks the tree to redirect to the next incomplete step', () => {
+      const incompleteStep = { path: '/incomplete' };
+      fakeJourney.instance.returns(fakeStep);
+      fakeFlowControl.last.returns(incompleteStep);
+
+      new SmartRedirector(fakeStep).redirect(fakeReq, fakeRes);
+
+      expect(fakeRes.redirect).calledOnce;
+      expect(fakeRes.redirect).calledWith(incompleteStep.path);
+    });
+
+    it('throws if the step doesnt have a flowControl', () => {
+      const noFlowControl = { name: 'NoFlow' };
+      fakeJourney.instance.returns(noFlowControl);
+
+      const callingRedirect = () => new SmartRedirector(fakeStep)
+        .redirect(fakeReq, fakeRes);
+
+      expect(callingRedirect).to.throw(/NoFlow does not have a flowControl/);
+    });
+  });
+});

--- a/test/steps/AddAnother.test.js
+++ b/test/steps/AddAnother.test.js
@@ -7,7 +7,7 @@ const {
   METHOD_NOT_ALLOWED
 } = require('http-status-codes');
 const { text } = require('../../src/forms');
-const { goTo } = require('../../src/flow');
+const { redirectTo } = require('../../src/flow');
 
 describe('steps/AddAnother', () => {
   class AddAText extends AddAnother {
@@ -19,7 +19,7 @@ describe('steps/AddAnother', () => {
     }
 
     next() {
-      return goTo({ path: '/next-step' });
+      return redirectTo({ path: '/next-step' });
     }
   }
 

--- a/test/steps/EntryPoint.test.js
+++ b/test/steps/EntryPoint.test.js
@@ -1,7 +1,7 @@
 const { testStep } = require('../util/supertest');
 const { expect } = require('../util/chai');
 const EntryPoint = require('../../src/steps/EntryPoint');
-const { goTo } = require('../../src/flow');
+const { redirectTo } = require('../../src/flow');
 
 describe('steps/EntryPoint', () => {
   it('expects #next to be implemented', () => {
@@ -15,7 +15,7 @@ describe('steps/EntryPoint', () => {
     const fakeStep = { path: '/bar' };
     const redirect = class MyEntryPoint extends EntryPoint {
       next() {
-        return goTo(fakeStep);
+        return redirectTo(fakeStep);
       }
     };
 
@@ -48,7 +48,7 @@ describe('steps/EntryPoint', () => {
       const fakeStep = { path: '/bar' };
       const redirect = class extends EntryPoint {
         next() {
-          return goTo(fakeStep);
+          return redirectTo(fakeStep);
         }
       };
       return testStep(redirect)

--- a/test/steps/Redirect.test.js
+++ b/test/steps/Redirect.test.js
@@ -1,7 +1,7 @@
 const { testStep } = require('../util/supertest');
 const { expect } = require('../util/chai');
 const Redirect = require('../../src/steps/Redirect');
-const { goTo } = require('../../src/flow');
+const { redirectTo } = require('../../src/flow');
 
 describe('steps/Redirect', () => {
   it('expects #next to be implemented', () => {
@@ -16,7 +16,7 @@ describe('steps/Redirect', () => {
       const fakeStep = { path: '/bar' };
       const redirect = class extends Redirect {
         next() {
-          return goTo(fakeStep);
+          return redirectTo(fakeStep);
         }
       };
       return testStep(redirect)
@@ -31,7 +31,7 @@ describe('steps/Redirect', () => {
       const fakeStep = { path: '/bar' };
       const redirect = class extends Redirect {
         next() {
-          return goTo(fakeStep);
+          return redirectTo(fakeStep);
         }
       };
       return testStep(redirect)


### PR DESCRIPTION
This PR uses the tree walking introduced by CheckYourAnswers to modify the behaviour of the `goTo` flow control to walk the tree from the next step declared in the `goTo` and find the next step following that path which is not yet complete. 

The existing functionality to `goTo` (always redirect to the given step) persists but has been moved to the new `redirectTo` flow control.