### PR TITLE
Stop suppressing errors from the flowControls, such as infinite loops

### DIFF
--- a/src/flow/smartRedirector.js
+++ b/src/flow/smartRedirector.js
@@ -1,14 +1,14 @@
 const Redirector = require('./redirector');
+const { defined } = require('../util/checks');
 
 class SmartRedirector extends Redirector {
   redirect(req, res) {
     const instance = req.journey.instance(this.nextStep);
-    try {
-      const nextStep = instance.flowControl.last();
-      res.redirect(nextStep.path);
-    } catch (error) {
+    if (!defined(instance.flowControl)) {
       throw new Error(`${instance.name} does not have a flowControl.`);
     }
+    const nextStep = instance.flowControl.last();
+    res.redirect(nextStep.path);
   }
 }
 


### PR DESCRIPTION
This PR narrows the scope of the check for a step not having a flow control, which stops us from suppressing other errors. Before this change if `flowControl.last` failed, for example for an infinite loop, then you would get a confusing "Step does not have a flowControl" error message.