### PR TITLE
Peg deepmerge at 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "connect-redis": "^3.3.2",
     "cookie-parser": "^1.4.3",
     "debug": "^3.1.0",
-    "deepmerge": "^2.0.1",
+    "deepmerge": "2.0.1",
     "express": "^4.16.2",
     "express-nunjucks": "^2.2.3",
     "express-session": "^1.15.6",


### PR DESCRIPTION
There is a breaking change with the dependency `deepmerge` v2.10, therefore, until
the framework code can be fixed I'm pegging deepmerge at 2.0.1 as this is known to work.