### PR TITLE
Enable testing of content on page

### DIFF
--- a/src/i18n/contentProxy.js
+++ b/src/i18n/contentProxy.js
@@ -20,6 +20,10 @@ const contentProxy = (step, prefix) => {
         return isToString || isInspect;
       };
     }
+    if (name === 'keys') {
+      const content = target.getResourceBundle(target.language, `${step.name}`);
+      return Object.keys(content);
+    }
     const key = `${step.name}:${prefix}`;
     if (toStringKeys.includes(name)) {
       if (target.exists(key)) {

--- a/test/util/supertest.js
+++ b/test/util/supertest.js
@@ -70,6 +70,11 @@ const wrapWithResponseAssertions = supertestObj => {
       return assertions($);
     });
   };
+  supertestObj.text = assertions => {
+    return supertestObj.then(res => {
+      return assertions(res.text);
+    });
+  };
   supertestObj.session = assertions => {
     return supertestObj.then(res => {
       // const sid = cookies(res);


### PR DESCRIPTION
These changes allow the developer to test the content that is rendered on a page using the [one-per-page-test-suite](https://github.com/hmcts/one-per-page-test-suite)