### PR TITLE
Custom session options

### DIFF
--- a/src/session/index.js
+++ b/src/session/index.js
@@ -15,10 +15,10 @@ const redisOrInMemory = (options = {}) => {
 
 const sessionOptions = userOpts => {
   const userCookie = userOpts.cookie || {};
-  const cookie = Object.assign({}, userCookie, {
+  const cookie = Object.assign({}, {
     secure: defaultIfUndefined(userCookie.secure, !isTest),
     expires: defaultIfUndefined(userCookie.expires, false)
-  });
+  }, userCookie);
 
   return {
     store: userOpts.store || redisOrInMemory(userOpts),


### PR DESCRIPTION
- In SYA we have a requirement to have the session age set at 20 minutes.
- Currently you can pass the `maxAge` option to one-per-page. However as per the documentation of express-session, https://github.com/expressjs/session#cookieexpires, what ever is set last between `expires` and `maxAge` will be used. Therefore our `maxAge` option will not be used.
- To fix this: In `session/index.js`, swap the order that the default options and custom options are merged into one, so that the custom options are set last.