### PR TITLE
AJAX Validation handling

### DIFF
--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -170,10 +170,6 @@ class AddAnother extends Question {
     return { validationErrors };
   }
 
-  get xhr() {
-    return this.req.xhr || this.req.headers['X-Requested-With'] === 'XMLHttpRequest';
-  }
-
   static get pathToBind() {
     // return `${super.path}/foo(\\d)/`;
     return `${super.path}(?:/item-(\\d{1,})/?(?:(delete)/?)?)?`;

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -147,7 +147,8 @@ class AddAnother extends Question {
     const validationErrors = fieldList.map(field => {
       return {
         field,
-        errors: fields[field].errors
+        errors: fields[field].errors,
+        value: fields[field].value
       };
     });
     return { validationErrors };

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -105,16 +105,15 @@ class AddAnother extends Question {
     } else if (req.method === 'POST') {
       this.parse();
       this.validate();
-
       if (this.valid) {
         this.store();
-        if (req.xhr) {
+        if (this.xhr) {
           res.status(OK).json({ validationErrors: [] });
         } else {
           res.redirect(this.path);
         }
       } else {
-        if (req.xhr) {
+        if (this.xhr) {
           res.json(this.buildValidationErrors);
         } else {
           res.render(this.template, this.locals);
@@ -148,18 +147,31 @@ class AddAnother extends Question {
 
   get buildValidationErrors() {
     let validationErrors = [];
-    if (this.fields.item && this.fields.item.fields) {
-      const fields = this.fields.item.fields;
-      const fieldList = Object.keys(fields);
-      validationErrors = fieldList.map(field => {
-        return {
-          field,
-          errors: fields[field].errors,
-          value: fields[field].value
+
+    if (this.fields.item) {
+      if (this.fields.item.fields) {
+        const fields = this.fields.item.fields;
+        const fieldList = Object.keys(fields);
+        validationErrors = fieldList.map(field => {
+          return {
+            field,
+            errors: fields[field].errors,
+            value: fields[field].value
+          };
+        });
+      } else {
+        validationErrors = {
+          field: this.fields.item.name,
+          errors: this.fields.item.errors,
+          value: this.fields.item.value
         };
-      });
+      }
     }
     return { validationErrors };
+  }
+
+  get xhr() {
+    return this.req.xhr || this.req.headers['X-Requested-With'] === 'XMLHttpRequest';
   }
 
   static get pathToBind() {

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -111,7 +111,7 @@ class AddAnother extends Question {
         res.redirect(this.path);
       } else {
         if (req.xhr) {
-          res.send(this.locals);
+          res.json(this.buildValidationErrors(this.locals.fields.item.fields));
         } else {
           res.render(this.template, this.locals);
         }
@@ -140,6 +140,17 @@ class AddAnother extends Question {
       }
     }
     res.redirect(this.path);
+  }
+
+  buildValidationErrors(fields) {
+    const fieldList = Object.keys(fields);
+    const validationErrors = fieldList.map(field => {
+      return {
+        field,
+        errors: fields[field].errors
+      };
+    });
+    return { validationErrors };
   }
 
   static get pathToBind() {

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -148,7 +148,7 @@ class AddAnother extends Question {
 
   get buildValidationErrors() {
     let validationErrors = [];
-    if (this.fields.item) {
+    if (this.fields.item && this.fields.item.fields) {
       const fields = this.fields.item.fields;
       const fieldList = Object.keys(fields);
       validationErrors = fieldList.map(field => {

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -110,7 +110,11 @@ class AddAnother extends Question {
         this.store();
         res.redirect(this.path);
       } else {
-        res.render(this.template, this.locals);
+        if (req.xhr) {
+          res.send(this.locals);
+        } else {
+          res.render(this.template, this.locals);
+        }
       }
     } else {
       res.redirect(this.path);

--- a/src/steps/AddAnother.js
+++ b/src/steps/AddAnother.js
@@ -3,7 +3,7 @@ const { defined } = require('../util/checks');
 const { flattenObject } = require('../util/ops');
 const { filledForm } = require('../forms/filledForm');
 const { form, list, appendToList } = require('../forms');
-const { METHOD_NOT_ALLOWED, OK } = require('http-status-codes');
+const { METHOD_NOT_ALLOWED, OK, UNPROCESSABLE_ENTITY } = require('http-status-codes');
 const { expectImplemented } = require('../errors/expectImplemented');
 
 class AddAnother extends Question {
@@ -114,7 +114,7 @@ class AddAnother extends Question {
         }
       } else {
         if (this.xhr) {
-          res.json(this.buildValidationErrors);
+          res.status(UNPROCESSABLE_ENTITY).json(this.buildValidationErrors);
         } else {
           res.render(this.template, this.locals);
         }

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -30,7 +30,11 @@ class Question extends Page {
     if (this.fields.isFilled) {
       this.validate();
     }
-    this.res.render(this.template, this.locals);
+    if (this.req.xhr) {
+      this.res.send(this.fields.items.fields);
+    } else {
+      this.res.render(this.template, this.locals);
+    }
   }
 
   handler(req, res, next) {

--- a/src/steps/Question.js
+++ b/src/steps/Question.js
@@ -30,8 +30,8 @@ class Question extends Page {
     if (this.fields.isFilled) {
       this.validate();
     }
-    if (this.req.xhr) {
-      this.res.send(this.fields.items.fields);
+    if (this.xhr) {
+      this.res.send(this.fields);
     } else {
       this.res.render(this.template, this.locals);
     }
@@ -117,6 +117,10 @@ class Question extends Page {
 
   get valid() {
     return this.fields.valid;
+  }
+
+  get xhr() {
+    return this.req.xhr || this.req.headers['X-Requested-With'] === 'XMLHttpRequest';
   }
 }
 

--- a/test/steps/AddAnother.test.js
+++ b/test/steps/AddAnother.test.js
@@ -414,9 +414,7 @@ describe('steps/AddAnother', () => {
       it('sends json with empty validation when field is valid and request is an ajax', () => {
         const validationErrors = { validationErrors: [] };
         return testStep(AddAText)
-          .withSetup(req => {
-            req.headers['X-Requested-With'] = 'XMLHttpRequest';
-          })
+          .withSetup(req => req.headers['X-Requested-With'] = 'XMLHttpRequest')
           .withField('item', 'foo')
           .withSession({})
           .post('/add-a-text/item-0')
@@ -456,9 +454,7 @@ describe('steps/AddAnother', () => {
           }
         };
         return testStep(ValidateAText)
-          .withSetup(req => {
-            req.headers['X-Requested-With'] = 'XMLHttpRequest';
-          })
+          .withSetup(req => req.headers['X-Requested-With'] = 'XMLHttpRequest')
           .withField('item', 'foo')
           .withSession({})
           .post('/validate-a-text/item-0')
@@ -482,9 +478,7 @@ describe('steps/AddAnother', () => {
           }]
         };
         return testStep(ValidateAText)
-          .withSetup(req => {
-            req.headers['X-Requested-With'] = 'XMLHttpRequest';
-          })
+          .withSetup(req => req.headers['X-Requested-With'] = 'XMLHttpRequest')
           .withField('item.a', 'foo')
           .withSession({})
           .post('/validate-a-text/item-0')

--- a/test/steps/AddAnother.test.js
+++ b/test/steps/AddAnother.test.js
@@ -4,7 +4,8 @@ const { testStep } = require('../util/supertest');
 const {
   OK,
   MOVED_TEMPORARILY,
-  METHOD_NOT_ALLOWED
+  METHOD_NOT_ALLOWED,
+  UNPROCESSABLE_ENTITY
 } = require('http-status-codes');
 const { text, object } = require('../../src/forms');
 const { errorFor } = require('../../src/forms/validator');
@@ -458,7 +459,7 @@ describe('steps/AddAnother', () => {
           .withField('item', 'foo')
           .withSession({})
           .post('/validate-a-text/item-0')
-          .expect(OK)
+          .expect(UNPROCESSABLE_ENTITY)
           .text(json => {
             return expect(json).to.equal(JSON.stringify(validationErrors));
           });
@@ -482,7 +483,7 @@ describe('steps/AddAnother', () => {
           .withField('item.a', 'foo')
           .withSession({})
           .post('/validate-a-text/item-0')
-          .expect(OK)
+          .expect(UNPROCESSABLE_ENTITY)
           .text(json => {
             return expect(json).to.equal(JSON.stringify(validationErrors));
           });

--- a/test/steps/Question.test.js
+++ b/test/steps/Question.test.js
@@ -42,6 +42,25 @@ describe('steps/Question', () => {
           });
       });
 
+      it('sends a response on GET when request is an ajax', () => {
+        const fieldsResponse = {
+          name: {
+            id: 'name',
+            name: 'name',
+            validations: []
+          }
+        };
+        return testStep(SimpleQuestion)
+          .withSetup(req => {
+            req.headers['X-Requested-With'] = 'XMLHttpRequest';
+            req.session.generate();
+          })
+          .get()
+          .text(response => {
+            expect(response).to.equal(JSON.stringify(fieldsResponse));
+          });
+      });
+
       it('loads fields from the session', () => {
         return testStep(SimpleQuestion)
           .withSetup(req => {


### PR DESCRIPTION
- This is to handle validation errors when using to AJAX to post values within the Add Another class.
- It checks if the request is an AJAX or not and if so build an object that contains the field within `item` and its errors.
- Then send it to the AJAX callback.

This is what is the errors object looks like:
```
{ validationErrors: [{ 
        field: 'whatYouDisagreeWith', errors: [Array], value: 'invalid field value' 
    }, { 
        field: 'reasonForAppealing', errors: [Array], value: 'invalid field value' 
    } 
]}
```

- Added the ability to use ajax to get the values of the fields
- Added unit tests for all