### PR TITLE
Do not continue to error handling if 422

### DIFF
--- a/src/errors/errorPages.js
+++ b/src/errors/errorPages.js
@@ -1,5 +1,5 @@
 // const { Page } = require('@hmcts/one-per-page');
-const { NOT_FOUND, INTERNAL_SERVER_ERROR } = require('http-status-codes');
+const { NOT_FOUND, INTERNAL_SERVER_ERROR, UNPROCESSABLE_ENTITY } = require('http-status-codes');
 const i18next = require('i18next');
 const path = require('path');
 const { i18NextInstance } = require('../i18n/i18Next');
@@ -35,6 +35,13 @@ class ErrorPages {
               )
             }
           );
+        });
+
+        app.use((req, res, next) => {
+          if (res.status === UNPROCESSABLE_ENTITY) {
+            return;
+          }
+          next();
         });
 
         app.use((req, res) => {


### PR DESCRIPTION
When we upload a file in SYA, we may need to cancel the request if the file is too big or of the type of the file is not allowed. Since we emit an error to cancel it, the request seems to unavoidably assume a 500 status. 

            incoming.once('fileBegin', function fileBegin(field, file) {
                if (!fileTypeWhitelist.find(el => el === file.type)) {
                  return this.emit('error', wrongFileTypeError);
                }
               if (file.size > maxFileSize) {
                 return this.emit('error', maxFileSizeExceededError);
               }
              return true;
            });

The idea is that we want to have an error, but we don't want any redirection to occur. In the code of SYA we should have something like:

    // in incomingFile.parse
    ......
    if (uploadingError || !files.uploadEv.name) {
            logger.warn('an error has occured with form upload', uploadingError);
            res.status = 422;
            req.body = {
              uploadEv: uploadingError
            };
            return next();
          }
       ......
that would then be caught by validation, therefore obtaining what we want: the same page of the upload, with the errors displayed.

Due to my limited knowledge of the framework, it's possible that I am taking a long-winded way to obtain this result: I am surprised indeed that there isn't a more obvious one. Simply doing `next(error)` produces a 500, which we don't want.

Please do not merge (yet?) this PR, but I'd like to know your thoughts about this issue.


