### PR TITLE
Fix for Delete ajax maximum call stack exceeded

### DIFF
--- a/src/i18n/contentProxy.js
+++ b/src/i18n/contentProxy.js
@@ -10,6 +10,8 @@ const prefixKey = (prefix, key) => {
 
 const toStringKeys = ['toString', Symbol.toStringTag];
 const inspectKeys = ['inspect', util.inspect.custom];
+const toJsonKeys = ['toJSON'];
+const observersKeys = ['observers'];
 
 const contentProxy = (step, prefix) => {
   const get = (target, name) => {
@@ -27,7 +29,7 @@ const contentProxy = (step, prefix) => {
       return Object.keys(content);
     }
     const key = `${step.name}:${prefix}`;
-    if (toStringKeys.includes(name)) {
+    if (toStringKeys.includes(name) || toJsonKeys.includes(name) || observersKeys.includes(name)) {
       if (target.exists(key)) {
         return () => target.t(key, step.locals);
       }


### PR DESCRIPTION
- This fixes and issue which has occurred when using the delete ajax endpoint. It currently comes up with an error for `maximum call stack exceeded` and it occurs in the contentProxy file. 

- I'm not currently sure why or how it happens but when getting the content, either `observers` or `toJSON` is appended to the object. It continually does this until the error is thrown e.g. `datesCantAttend.fields.error.notEnough.observers.observers.oberservers` etc etc. 

- The fix is to do a similar thing that has been done previously for `toString`. Check if the name is either toJSON or observers and to return the actual target and content key if it exists. This seems to fix the issue. 