### PR TITLE
Adding previousPath to local so the template back button can point to it

### DIFF
--- a/src/flow/smartRedirector.js
+++ b/src/flow/smartRedirector.js
@@ -8,8 +8,10 @@ class SmartRedirector extends Redirector {
       throw new Error(`${instance.name} does not have a flowControl.`);
     }
     const nextStep = instance.flowControl.last();
-    req.session.previousPath = req.path;
-    req.session.save();
+    if (req && req.session) {
+      req.session.previousPath = req.path;
+      req.session.save();
+    }
     res.redirect(nextStep.path);
   }
 }

--- a/src/flow/smartRedirector.js
+++ b/src/flow/smartRedirector.js
@@ -8,6 +8,8 @@ class SmartRedirector extends Redirector {
       throw new Error(`${instance.name} does not have a flowControl.`);
     }
     const nextStep = instance.flowControl.last();
+    req.session.previousPath = req.path;
+    req.session.save();
     res.redirect(nextStep.path);
   }
 }

--- a/src/middleware/addLocals.js
+++ b/src/middleware/addLocals.js
@@ -2,7 +2,7 @@ const addLocals = (req, res, next) => {
   res.locals = res.locals || {};
   res.locals.url = req.currentStep.url;
   res.locals.content = req.currentStep.content;
-
+  res.locals.previousPath = req.session.previousPath;
   next();
 };
 


### PR DESCRIPTION
The story says that the back button needs to work without js.

Therefore it must be a link: this little hack make the templates able to access `previousPath` if it's possible to determine it. 

@bendiggle I am sure I am neglecting one or more arcane edge cases, please do advise :)