### PR TITLE
set cookie domain based on request

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "4.0.0",
+  "version": "3.4.4",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "3.4.3",
+  "version": "4.0.0",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/flow/journey.js
+++ b/src/flow/journey.js
@@ -30,7 +30,7 @@ const options = userOpts => {
   if (typeof userOpts.session === 'function') {
     sessionProvider = userOpts.session;
   } else {
-    const sessionOpts = Object.assign({}, userOpts.session, { cookie: {} });
+    const sessionOpts = Object.assign({ cookie: {} }, userOpts.session);
     sessionProvider = session(sessionOpts);
   }
   const steps = defaultIfUndefined(userOpts.steps, [])

--- a/src/flow/journey.js
+++ b/src/flow/journey.js
@@ -30,11 +30,7 @@ const options = userOpts => {
   if (typeof userOpts.session === 'function') {
     sessionProvider = userOpts.session;
   } else {
-    const cookie = Object.assign(
-      { domain: parseUrl(userOpts.baseUrl).hostname },
-      userOpts.session.cookie || {}
-    );
-    const sessionOpts = Object.assign({}, userOpts.session, { cookie });
+    const sessionOpts = Object.assign({}, userOpts.session, { cookie: {} });
     sessionProvider = session(sessionOpts);
   }
   const steps = defaultIfUndefined(userOpts.steps, [])

--- a/src/session/index.js
+++ b/src/session/index.js
@@ -17,8 +17,9 @@ const redisOrInMemory = (options = {}) => {
 const sessionOptions = (userOpts, store, req) => {
   const userCookie = userOpts.cookie || {};
   const cookie = Object.assign({}, {
-    secure: defaultIfUndefined(userCookie.secure, !isTest),
-    expires: defaultIfUndefined(userCookie.expires, false)
+    secure: req.secure,
+    expires: defaultIfUndefined(userCookie.expires, false),
+    domain: req.hostname
   }, userCookie);
 
   if (userOpts.sessionEncryption) {

--- a/src/session/index.js
+++ b/src/session/index.js
@@ -17,9 +17,9 @@ const redisOrInMemory = (options = {}) => {
 const sessionOptions = (userOpts, store, req) => {
   const userCookie = userOpts.cookie || {};
   const cookie = Object.assign({}, {
-    secure: req.secure,
+    secure: defaultIfUndefined(userCookie.secure, req.secure),
     expires: defaultIfUndefined(userCookie.expires, false),
-    domain: req.hostname
+    domain: defaultIfUndefined(userCookie.hostname, req.hostname)
   }, userCookie);
 
   if (userOpts.sessionEncryption) {

--- a/test/flow/journey.test.js
+++ b/test/flow/journey.test.js
@@ -104,6 +104,19 @@ describe('journey/journey', () => {
         expect(spy).calledWith(sinon.match({ secret }));
         expect(spy).calledWith(sinon.match({ cookie: {} }));
       });
+
+      it('accepts custom cookie options', () => {
+        const spy = sinon.spy(session);
+        const stubbedJourney = proxyquire(
+          '../../src/flow/journey',
+          { '../session': spy }
+        );
+        const domain = '127.0.0.1';
+        const baseUrl = `http://${domain}`;
+        const cookie = { customOption: true };
+        stubbedJourney(testApp(), { baseUrl, session: { cookie } });
+        expect(spy).calledWith(sinon.match({ cookie }));
+      });
     });
   });
 

--- a/test/flow/journey.test.js
+++ b/test/flow/journey.test.js
@@ -77,40 +77,6 @@ describe('journey/journey', () => {
     });
   });
 
-  describe('baseUrl option', () => {
-    let spy = null;
-    let stubbedJourney = null;
-
-    beforeEach(() => {
-      spy = sinon.spy(session);
-      stubbedJourney = proxyquire(
-        '../../src/flow/journey',
-        { '../session': spy }
-      );
-    });
-
-    const test = domain => () => {
-      const baseUrl = `http://${domain}:1231/foo/bar`;
-      stubbedJourney(testApp(), { baseUrl, session: { secret: 'foo' } });
-      return expect(spy).calledWith(sinon.match({ cookie: { domain } }));
-    };
-
-    it('used as default for cookie.domain (localhost)', test('localhost'));
-    it('used as default for cookie.domain (127.0.0.1)', test('127.0.0.1'));
-    it('used as default for cookie.domain (example.com)', test('example.com'));
-    it('used as default for cookie.domain (new tld)', test('allen.digital'));
-
-    it('wont override an explicit cookie.domain', () => {
-      const domain = 'explicit.override.com';
-      const baseUrl = 'http://base.url.com';
-      stubbedJourney(testApp(), {
-        baseUrl,
-        session: { secret: 'foo', cookie: { domain } }
-      });
-      return expect(spy).calledWith(sinon.match({ cookie: { domain } }));
-    });
-  });
-
   describe('session option', () => {
     describe('as a function', () => {
       it('overrides the session middleware', () => {
@@ -125,10 +91,6 @@ describe('journey/journey', () => {
     });
 
     describe('as an object', () => {
-      it('requires a baseUrl to be provided', () => {
-        expect(() => journey(testApp(), {})).to.throw('Must provide a baseUrl');
-      });
-
       it('configures the session middleware', () => {
         const spy = sinon.spy(session);
         const stubbedJourney = proxyquire(
@@ -140,7 +102,7 @@ describe('journey/journey', () => {
         const secret = 'keyboard cat';
         stubbedJourney(testApp(), { baseUrl, session: { secret } });
         expect(spy).calledWith(sinon.match({ secret }));
-        expect(spy).calledWith(sinon.match({ cookie: { domain } }));
+        expect(spy).calledWith(sinon.match({ cookie: {} }));
       });
     });
   });


### PR DESCRIPTION
In CNP we cannot get the correct url when on preview-staging environment, for this reason sessions are failing to be created successfully.

This PR uses the requested hostname to set the correct url.