### PR TITLE
Remove baseUrl

### DIFF
--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -70,7 +70,23 @@ journey(app, {
   errorPages: {},
   session: {
     redis: { url: config.redisUrl },
-    cookie: { secure: false }
+    cookie: {
+      // default req.hostname
+      domain: 'localhost',
+
+      // default: false
+      expires: false,
+
+      // default: req.secure
+      secure: false
+    },
+
+    // default: undefined
+    secret: config.secret,
+
+    // Optional, default: undefined
+    // return key to encryption session at rest ( redis )
+    sessionEncryption: (/* req */) => config.encryptionAtRestKey
   },
   apiUrl: `${baseUrl}/api/submit`
 });

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -49,7 +49,6 @@ lookAndFeel.configure(app, {
 });
 
 journey(app, {
-  baseUrl,
   steps: [
     Start,
     Entry,

--- a/examples/test-app/config/default.yml
+++ b/examples/test-app/config/default.yml
@@ -1,3 +1,4 @@
 port: 3000
 secret: 'iamnotaverygoodsecret'
 redisUrl: redis://127.0.0.1:6379
+encryptionAtRestKey: 'iamnotaverygoodsecret'

--- a/examples/test-app/yarn.lock
+++ b/examples/test-app/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@hmcts/look-and-feel@./../../../look-and-feel":
-  version "1.12.0"
+  version "1.13.0"
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
@@ -33,7 +33,7 @@
     webpack-dev-middleware "^2.0.4"
 
 "@hmcts/one-per-page@./../../":
-  version "2.5.1"
+  version "3.5.1"
   dependencies:
     "@log4js-node/log4js-api" "^1.0.0"
     body-parser "^1.18.2"
@@ -43,7 +43,7 @@
     connect-redis "^3.3.2"
     cookie-parser "^1.4.3"
     debug "^3.1.0"
-    deepmerge "^2.0.1"
+    deepmerge "2.0.1"
     express "^4.16.2"
     express-nunjucks "^2.2.3"
     express-session "^1.15.6"
@@ -1453,7 +1453,7 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
-deepmerge@^2.0.0, deepmerge@^2.0.1:
+deepmerge@2.0.1, deepmerge@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/flow/journey.js
+++ b/src/flow/journey.js
@@ -8,13 +8,6 @@ const RequestBoundJourney = require('./RequestBoundJourney');
 const log = require('../util/logging')('journey');
 const cookieParser = require('cookie-parser');
 
-const parseUrl = baseUrl => {
-  if (typeof baseUrl === 'undefined') {
-    throw new Error('Must provide a baseUrl');
-  }
-  return urlParse(baseUrl);
-};
-
 const constructorFrom = step => {
   if (defined(step.prototype)) {
     return step;
@@ -37,7 +30,6 @@ const options = userOpts => {
     .map(constructorFrom);
 
   return Object.assign({}, userOpts, {
-    baseUrl: userOpts.baseUrl,
     steps,
     session: sessionProvider,
     noSessionHandler: userOpts.noSessionHandler

--- a/src/flow/journey.js
+++ b/src/flow/journey.js
@@ -1,7 +1,6 @@
 const session = require('../session');
 const { i18nMiddleware } = require('../i18n/i18Next');
 const errorPages = require('../errors/errorPages');
-const urlParse = require('url-parse');
 const defaultIfUndefined = require('../util/defaultIfUndefined');
 const { defined } = require('../util/checks');
 const RequestBoundJourney = require('./RequestBoundJourney');

--- a/test/errors/errorPages.test.js
+++ b/test/errors/errorPages.test.js
@@ -10,8 +10,7 @@ const Page = require('../../src/steps/Page');
 
 describe('errors/errorPages', () => {
   const defaultOptions = {
-    session: { secret: 'foo' },
-    baseUrl: 'http://localhost'
+    session: { secret: 'foo' }
   };
   const options = (...overrides) => {
     const foo = Object.assign(

--- a/test/flow/journey.test.js
+++ b/test/flow/journey.test.js
@@ -7,10 +7,7 @@ const Page = require('../../src/steps/Page');
 const session = require('../../src/session');
 
 class TestPage extends Page {}
-const defaultOptions = {
-  session: { secret: 'foo' },
-  baseUrl: 'http://localhost'
-};
+const defaultOptions = { session: { secret: 'foo' } };
 const options = (...overrides) => {
   const foo = Object.assign(
     {},
@@ -97,10 +94,8 @@ describe('journey/journey', () => {
           '../../src/flow/journey',
           { '../session': spy }
         );
-        const domain = '127.0.0.1';
-        const baseUrl = `http://${domain}`;
         const secret = 'keyboard cat';
-        stubbedJourney(testApp(), { baseUrl, session: { secret } });
+        stubbedJourney(testApp(), { session: { secret } });
         expect(spy).calledWith(sinon.match({ secret }));
         expect(spy).calledWith(sinon.match({ cookie: {} }));
       });
@@ -111,10 +106,8 @@ describe('journey/journey', () => {
           '../../src/flow/journey',
           { '../session': spy }
         );
-        const domain = '127.0.0.1';
-        const baseUrl = `http://${domain}`;
         const cookie = { customOption: true };
-        stubbedJourney(testApp(), { baseUrl, session: { cookie } });
+        stubbedJourney(testApp(), { session: { cookie } });
         expect(spy).calledWith(sinon.match({ cookie }));
       });
     });
@@ -146,7 +139,6 @@ describe('journey/journey', () => {
 
       stubbedJourney(app,
         {
-          baseUrl: 'http://localhost',
           session: { secret: 'foo' },
           errorPages: errorPagesConfig
         }

--- a/test/util/supertest.js
+++ b/test/util/supertest.js
@@ -42,7 +42,7 @@ const supertestInstance = stepDSL => {
     next();
   });
 
-  app.use(session({ baseUrl: '127.0.0.1', secret: 'keyboard cat' }));
+  app.use(session({ secret: 'keyboard cat' }));
   app.use(cookieParser());
   app.use(i18nMiddleware);
 


### PR DESCRIPTION
Given the cookie domain is now set by the request (https://github.com/hmcts/one-per-page/pull/140) there is no need for a base Url on one-per-page.

Also added new config options to test app