### PR TITLE
Return nested keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/i18n/contentProxy.js
+++ b/src/i18n/contentProxy.js
@@ -26,7 +26,7 @@ const contentProxy = (step, prefix) => {
       const language = target.language || target.options.fallbackLng;
       const content = target
         .getResourceBundle(language, `${step.name}`);
-      return Object.keys(content);
+      return content;
     }
     const key = `${step.name}:${prefix}`;
     if (toStringKeys.includes(name) || toJsonKeys.includes(name) || observersKeys.includes(name)) {

--- a/test/i18n/contentProxy.test.js
+++ b/test/i18n/contentProxy.test.js
@@ -104,7 +104,7 @@ describe('i18n/contentProxy', () => {
 
     describe('#keys (used by one-per-page-test-suite)', () => {
       it('returns all keys for properties', () => {
-        expect(proxy.foo.keys).to.eql(['key']);
+        expect(proxy.foo.keys).to.eql({ key: 'key' });
       });
     });
   });


### PR DESCRIPTION
need to return full object to enable iterating through nested objects.

Used in the latest @hmcts/one-per-page-test-suite