### PR TITLE
Adding content sub folder to track diff stages content

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/i18n/loadStepContent.js
+++ b/src/i18n/loadStepContent.js
@@ -82,7 +82,6 @@ const loadStepContent = (step, i18Next) => {
     glob(`${step.dirname}/${step.name}.json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.@(*).json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.content.json`).then(loadContents),
-    glob(`${step.dirname}/${step.name}.content.@(*).json`).then(loadContents),
     glob(`${step.dirname}/**/*/${step.name}.content.@(*).json`).then(loadContents)
   ];
 

--- a/src/i18n/loadStepContent.js
+++ b/src/i18n/loadStepContent.js
@@ -82,7 +82,8 @@ const loadStepContent = (step, i18Next) => {
     glob(`${step.dirname}/${step.name}.json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.@(*).json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.content.json`).then(loadContents),
-    glob(`${step.dirname}/${step.name}.content.@(*).json`).then(loadContents)
+    glob(`${step.dirname}/${step.name}.content.@(*).json`).then(loadContents),
+    glob(`${step.dirname}/${step.name}/content/@(*).content.json`).then(loadContents)
   ];
 
   return Promise.all(promises);

--- a/src/i18n/loadStepContent.js
+++ b/src/i18n/loadStepContent.js
@@ -83,7 +83,7 @@ const loadStepContent = (step, i18Next) => {
     glob(`${step.dirname}/${step.name}.@(*).json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.content.json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.content.@(*).json`).then(loadContents),
-    glob(`${step.dirname}/${step.name}/content/@(*).content.json`).then(loadContents)
+    glob(`${step.dirname}/content/@(*).content.json`).then(loadContents)
   ];
 
   return Promise.all(promises);

--- a/src/i18n/loadStepContent.js
+++ b/src/i18n/loadStepContent.js
@@ -83,7 +83,7 @@ const loadStepContent = (step, i18Next) => {
     glob(`${step.dirname}/${step.name}.@(*).json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.content.json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.content.@(*).json`).then(loadContents),
-    glob(`${step.dirname}/content/@(*).content.json`).then(loadContents)
+    glob(`${step.dirname}/**/*/${step.name}.content.@(*).json`).then(loadContents)
   ];
 
   return Promise.all(promises);

--- a/src/i18n/loadStepContent.js
+++ b/src/i18n/loadStepContent.js
@@ -81,7 +81,6 @@ const loadStepContent = (step, i18Next) => {
     glob(`${step.dirname}/content.@(*).json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.json`).then(loadContents),
     glob(`${step.dirname}/${step.name}.@(*).json`).then(loadContents),
-    glob(`${step.dirname}/${step.name}.content.json`).then(loadContents),
     glob(`${step.dirname}/**/*/${step.name}.content.@(*).json`).then(loadContents)
   ];
 

--- a/test/i18n/fixtures/loadStepContent/StepName.content.section.json
+++ b/test/i18n/fixtures/loadStepContent/StepName.content.section.json
@@ -1,0 +1,5 @@
+{
+  "en": {
+    "StepName_dot_content_dot_json": "Expected Value"
+  }
+}

--- a/test/i18n/fixtures/loadStepContent/StepName.content.section.json
+++ b/test/i18n/fixtures/loadStepContent/StepName.content.section.json
@@ -1,5 +1,5 @@
 {
   "en": {
-    "StepName_dot_content_dot_json": "Expected Value"
+    "StepName_dot_content_dot_section_dot_json": "Expected Value"
   }
 }

--- a/test/i18n/loadStepContent.test.js
+++ b/test/i18n/loadStepContent.test.js
@@ -10,7 +10,8 @@ describe('i18n/loadStepContent', () => {
     'StepName.json',
     'StepName.en.json',
     'StepName.content.json',
-    'StepName.content.en.json'
+    'StepName.content.en.json',
+    'StepName.content.section.json'
   ];
 
   const testRoot = path.resolve(__dirname, './fixtures/loadStepContent');


### PR DESCRIPTION
As part of DIV-3266 changing the folder structure to accomodate different stages of content, so creating content subfolder to segregate content in different files. OPP has to load content sub folder and those changes are included in this PR.

<img width="362" alt="screen shot 2018-10-04 at 09 20 16" src="https://user-images.githubusercontent.com/43175082/46461531-c5b8d480-c7b6-11e8-81dd-f02cb3a6e8fe.png">
