### PR TITLE
Use middleware to load content

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/middleware/loadStepContent.js
+++ b/src/middleware/loadStepContent.js
@@ -1,0 +1,16 @@
+const loadStepContent = require('../i18n/loadStepContent');
+const { i18NextInstance } = require('../i18n/i18Next');
+
+const loadContent = step =>
+  (req, res, next) => {
+    loadStepContent
+      .loadStepContent(step, i18NextInstance)
+      .then(() => {
+        next();
+      })
+      .catch(error => {
+        next(`Unable to load content ${error}`);
+      });
+  };
+
+module.exports = loadContent;

--- a/src/steps/Page.js
+++ b/src/steps/Page.js
@@ -1,11 +1,11 @@
 const BaseStep = require('./BaseStep');
 const addLocals = require('../middleware/addLocals');
 const { METHOD_NOT_ALLOWED } = require('http-status-codes');
-const { loadStepContent } = require('../i18n/loadStepContent');
 const resolveTemplate = require('../middleware/resolveTemplate');
 const { i18NextInstance } = require('../i18n/i18Next');
 const { contentProxy } = require('../i18n/contentProxy');
 const { defined } = require('../util/checks');
+const loadStepContent = require('../middleware/loadStepContent');
 
 const notLocals = [
   '_router',
@@ -38,11 +38,15 @@ class Page extends BaseStep {
   constructor(...args) {
     super(...args);
     this.content = new Proxy(i18NextInstance, contentProxy(this));
-    this.waitFor(loadStepContent(this, i18NextInstance));
   }
 
   get middleware() {
-    return [...super.middleware, resolveTemplate, addLocals];
+    return [
+      loadStepContent(this),
+      ...super.middleware,
+      resolveTemplate,
+      addLocals
+    ];
   }
 
   get locals() {

--- a/test/middleware/loadStepContent.test.js
+++ b/test/middleware/loadStepContent.test.js
@@ -1,0 +1,33 @@
+const loadStepContent = require('../../src/i18n/loadStepContent');
+const loadStepContentMiddleware = require('../../src/middleware/loadStepContent');
+const { expect, sinon } = require('../util/chai');
+
+describe('middleware/loadStepContent', () => {
+  beforeEach(() => {
+    sinon.stub(loadStepContent, 'loadStepContent');
+  });
+
+  afterEach(() => {
+    loadStepContent.loadStepContent.restore();
+  });
+
+  it('calls the loadStepContent and then calls done', done => {
+    loadStepContent.loadStepContent.resolves();
+    const middleware = loadStepContentMiddleware();
+    middleware({}, {}, () => {
+      expect(loadStepContent.loadStepContent.calledOnce).to.eql(true);
+      done();
+    });
+  });
+
+  it('calls next with error if not able to load content', done => {
+    const theError = new Error();
+    loadStepContent.loadStepContent.rejects(theError);
+    const middleware = loadStepContentMiddleware();
+    middleware({}, {}, error => {
+      expect(loadStepContent.loadStepContent.calledOnce).to.eql(true);
+      expect(error).to.eql('Unable to load content Error');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
For some reason promises are failing to load content occasionally on AAT.

This PR moves content loading to middleware.