### PR TITLE
ability to bind custom routes to app

### DIFF
--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -60,7 +60,16 @@ lookAndFeel.configure(app, {
   }
 });
 
+const customRoute = {
+  bind: theApp => {
+    theApp.use('/my-custom-route', (req, res) => {
+      res.send();
+    });
+  }
+};
+
 journey(app, {
+  routes: [customRoute],
   steps: [
     Start,
     Entry,

--- a/examples/test-app/app.js
+++ b/examples/test-app/app.js
@@ -63,6 +63,7 @@ lookAndFeel.configure(app, {
 const customRoute = {
   bind: theApp => {
     theApp.use('/my-custom-route', (req, res) => {
+      // do some stuff
       res.send();
     });
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/flow/journey.js
+++ b/src/flow/journey.js
@@ -29,10 +29,13 @@ const options = userOpts => {
   const steps = defaultIfUndefined(userOpts.steps, [])
     .map(constructorFrom);
 
+  const routes = defaultIfUndefined(userOpts.routes, []);
+
   return Object.assign({}, userOpts, {
     steps,
     session: sessionProvider,
-    noSessionHandler: userOpts.noSessionHandler
+    noSessionHandler: userOpts.noSessionHandler,
+    routes
   });
 };
 
@@ -60,6 +63,14 @@ const journey = (app, userOpts) => {
   app.use(setupMiddleware);
   app.use(opts.session);
   app.use(i18nMiddleware);
+
+  opts.routes.forEach(route => {
+    if (!route.hasOwnProperty('bind')) {
+      // eslint-disable-next-line max-len
+      throw new TypeError('Your custom route should have a bind function i.e. bind: app => {}');
+    }
+    return route.bind(app);
+  });
 
   opts.steps.forEach(Step => Step.bind(app));
   errorPages.bind(app, userOpts.errorPages);

--- a/test/flow/journey.test.js
+++ b/test/flow/journey.test.js
@@ -47,6 +47,27 @@ describe('journey/journey', () => {
     return supertest(app).get(TestPage.path).expect(OK);
   });
 
+  it('binds custom routes to the router', () => {
+    const routes = [
+      {
+        bind: app => {
+          app.use('/custom-route', (req, res) => res.send());
+        }
+      }
+    ];
+    const app = journey(testApp(), options({ routes }));
+    return supertest(app).get('/custom-route').expect(OK);
+  });
+
+  it('thowes an error if route doesnt have bind function', () => {
+    const shouldThrowError = () => {
+      journey(testApp(), options({ routes: [{}] }));
+    };
+    return expect(shouldThrowError)
+      // eslint-disable-next-line max-len
+      .throws('Your custom route should have a bind function i.e. bind: app => {}');
+  });
+
   describe('req.journey', () => {
     it('is created by journey', handlerTest({
       test(req) {


### PR DESCRIPTION
ability to bind custom routes to app by adding following to config:
```
const customRoute = {
  bind: theApp => {
    theApp.use('/my-custom-route', (req, res) => {
      // do some stuff
      res.send();
    });
  }
};

journey(app, {
  routes: [customRoute],
  ....
```