### PR TITLE
Unescape HTML entities after santisation so special characters are no…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hmcts/one-per-page",
   "description": "One question per page apps made easy",
   "homepage": "https://github.com/hmcts/one-per-page#readme",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "main": "./src/main.js",
   "repository": {
     "type": "git",

--- a/src/middleware/sanitizeRequestBody.js
+++ b/src/middleware/sanitizeRequestBody.js
@@ -5,7 +5,8 @@ const emoji = require('node-emoji');
 const { flow } = require('lodash');
 
 const sanitizeRequestBody = (req, res, next) => {
-  const santizeValue = flow([emoji.strip, sanitizer.sanitize]);
+  // Strip emojis, remove scripts then restore special characters
+  const santizeValue = flow([emoji.strip, sanitizer.sanitize, sanitizer.unescapeEntities]);
 
   traverse(req.body).forEach(function sanitizeValue(value) {
     if (this.isLeaf) {

--- a/test/middleware/sanitizeRequestBody.test.js
+++ b/test/middleware/sanitizeRequestBody.test.js
@@ -11,16 +11,18 @@ let req = {};
 describe('sanitizeRequestBody', () => {
   beforeEach(() => {
     sanitizerSpy = sinon.spy(sanitizer, 'sanitize');
+    unescapeSpy = sinon.spy(sanitizer, 'unescapeEntities');
     emojiSpy = sinon.spy(emoji, 'strip');
     req = {};
   });
 
   afterEach(() => {
     sanitizerSpy.restore();
+    unescapeSpy.restore();
     emojiSpy.restore();
   });
 
-  it('runs sanitizer and emoji stripper on each item in body', done => {
+  it('runs sanitizer, unescape and emoji stripper on each item in body', done => {
     req.body = {
       foo: 'value1',
       bar: { bar: 'value2', baz: ['array1', 'array2', 'array3'] }
@@ -28,14 +30,19 @@ describe('sanitizeRequestBody', () => {
 
     sanitizeRequestBody(req, {}, () => {
       expect(sanitizerSpy.withArgs('value1')).calledOnce;
+      expect(unescapeSpy.withArgs('value1')).calledOnce;
       expect(emojiSpy.withArgs('value1')).calledOnce;
       expect(sanitizerSpy.withArgs('value2')).calledOnce;
+      expect(unescapeSpy.withArgs('value2')).calledOnce;
       expect(emojiSpy.withArgs('value2')).calledOnce;
       expect(sanitizerSpy.withArgs('array1')).calledOnce;
+      expect(unescapeSpy.withArgs('array1')).calledOnce;
       expect(emojiSpy.withArgs('array1')).calledOnce;
       expect(sanitizerSpy.withArgs('array2')).calledOnce;
+      expect(unescapeSpy.withArgs('array2')).calledOnce;
       expect(emojiSpy.withArgs('array2')).calledOnce;
       expect(sanitizerSpy.withArgs('array3')).calledOnce;
+      expect(unescapeSpy.withArgs('array3')).calledOnce;
       expect(emojiSpy.withArgs('array3')).calledOnce;
       done();
     });
@@ -52,6 +59,19 @@ describe('sanitizeRequestBody', () => {
     sanitizeRequestBody(req, {}, () => {
       Object.keys(req.body).forEach(key => {
         expect(req.body[key]).to.eql('some text');
+      });
+      done();
+    });
+  });
+
+  it('does not modify special characters', done => {
+    req.body = {
+      script: 'special characters & >< some script tags<script>Hello World</script>'
+    };
+
+    sanitizeRequestBody(req, {}, () => {
+      Object.keys(req.body).forEach(key => {
+        expect(req.body[key]).to.eql('special characters & >< some script tags');
       });
       done();
     });


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DIV-5552](https://tools.hmcts.net/jira/browse/DIV-5552)

### Change description ###

Unescape the strings in the request body after santisation, which strips script tags and changes special characters to HTML entities, e.g. & to &amp ;

The script tags are fully removed, so the unescape will only affect remaining special characters.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
